### PR TITLE
Add MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Open Hospitality Network
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "sleepy.bike",
   "version": "0.1.0",
+  "license": "MIT",
   "private": true,
   "dependencies": {
     "@inrupt/solid-client-authn-browser": "^1.13.0",


### PR DESCRIPTION
Using permissive license is important for me, but i can imagine other people might prefer copyleft.

The thing is, i don't ever use copyleft-licensed libraries, because it limits my freedom of choice.

We may want to extract solid-hospex-core library from this project. Such library would handle data, would be framework-agnostic, and people would be able to build their own community on top of it. I'd really love to see that one have permissive license - i want to contribute to libraries that i can actually use.

But this may be a controversial topic.

If we don't reach consensus, [double licensing](https://en.wikipedia.org/wiki/Multi-licensing) (choose either MIT, or copyleft), is an option.

## Some projects using permissive (MIT etc.) license

most of widely used Javascript/Typescript libraries that i know and use
https://github.com/karrot-dev/karrot-frontend
https://github.com/Couchers-org/couchers

## Some projects using copyleft (AGPL-3.0 etc.) license

https://github.com/BeWelcome/rox
https://github.com/karrot-dev/karrot-backend
https://github.com/trustroots/trustroots
https://github.com/mastodon/mastodon

## Some projects using multi-licensing

https://codeberg.org/openEngiadina