### PR TITLE
Fix bug: resolve relative acl link to absolute one

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -109,11 +109,15 @@ const generateIteratively = <T>(
   return Array.from(seen)
 }
 
+/**
+ * Find link to ACL document for a given URI
+ */
 export const getAcl = async (uri: URI) => {
   const response = await fetch(uri, { method: 'HEAD' })
   const linkHeader = response.headers.get('link')
   const links = parseLinkHeader(linkHeader)
   const aclUri = links?.acl?.url
   if (!aclUri) throw new Error(`We could not find WAC link for ${uri}`)
-  return aclUri
+  // if aclUri is relative, return absolute uri
+  return new URL(aclUri, uri).toString()
 }


### PR DESCRIPTION
Bug discovered by @mariha 

The Node Solid Server provides link to document's ACL as a relative path. We didn't take that into account before.

It was impossible to join with Node Solid Server before.

[More info](https://solidproject.org/TR/wac#effective-acl-resource)

Dictionary:

_ACL_ - access control list - Each resource and container on Solid Pod has an associated document (ACL), where it can be specified who has access to the resource or container. We can discover this ACL by looking for `Link` header with `rel=acl` in the resource's response. Often, it's just the url of the resource or container + `.acl`. If ACL isn't present, parent container's ACL is used.
