### PR TITLE
Add a workflow to notify matrix room when an issue is created

### DIFF
--- a/.github/workflows/notify-on-issues.yml
+++ b/.github/workflows/notify-on-issues.yml
@@ -1,0 +1,17 @@
+name: Notify matrix room when an issue is created
+
+on:
+  issues:
+    types: [opened, reopened, transferred]
+
+jobs:
+  ping_matrix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: send message for an issue
+        uses: s3krit/matrix-message-action@v0.0.3
+        with:
+          room_id: ${{ secrets.MATRIX_ROOM_ID }}
+          access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+          message: "${{ github.event.issue.user.login }} has just opened an issue: [${{ github.event.issue.title }}](${{ github.event.issue.html_url }})"
+          server: "matrix.org"


### PR DESCRIPTION
We have similar workflows in other repos. This allows for people who are not in GH to notice and react / comment to the issues.

We could consider using some more internal room then our "general" channel.