### PR TITLE
Add info about sleepy.bike to front page and meta description

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Decentralized hospitality exchange community for slow travellers"
+      content="Sleepy Bike is a community of bicycle touring travellers and those who want to host them. It's decentralized. Members own their data and will be able to connect with other similar communities in the greater hospitality exchange network."
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Sleepy Bike &mdash; decentralized hospex for slow travellers</title>
+    <title>Sleepy Bike</title>
 
     <!-- Start Single Page Apps for GitHub Pages -->
     <script type="text/javascript">

--- a/src/pages/UnauthenticatedHome.module.scss
+++ b/src/pages/UnauthenticatedHome.module.scss
@@ -1,0 +1,58 @@
+.wrapper {
+  height: 100%;
+  padding-bottom: 3rem;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4rem;
+
+  text-align: justify;
+
+  .mainDescription {
+    font-size: 1.2rem;
+  }
+
+  .actions {
+    button {
+      padding: 1rem;
+      font-size: 1.2rem;
+    }
+  }
+
+  .projects {
+    max-width: 20rem;
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    gap: 1rem;
+    text-align: center;
+
+    .project {
+      display: grid;
+      grid-template-rows: 2fr 1fr;
+      align-items: start;
+      justify-items: center;
+      gap: 1rem;
+
+      .logo {
+        height: 6rem;
+        width: 6rem;
+      }
+    }
+
+    .plus {
+      font-size: 3rem;
+    }
+  }
+
+  .spacer {
+    flex: auto;
+  }
+
+  .footer {
+    a {
+      text-decoration: underline;
+    }
+  }
+}

--- a/src/pages/UnauthenticatedHome.tsx
+++ b/src/pages/UnauthenticatedHome.tsx
@@ -1,13 +1,55 @@
-import { ButtonLink } from 'components'
 import { SignIn } from 'components/SignIn/SignIn'
+import styles from './UnauthenticatedHome.module.scss'
 
 export const UnauthenticatedHome = () => {
   return (
-    <div>
-      <SignIn />
-      <ButtonLink tertiary to="about">
+    <div className={styles.wrapper}>
+      <section className={styles.mainDescription}>
+        Sleepy Bike is a community of bicycle touring travellers and those who
+        want to host them.
+      </section>
+      <section className={styles.actions}>
+        <SignIn />
+      </section>
+      <div className={styles.projects}>
+        <a href="https://openhospitality.network" className={styles.project}>
+          <img
+            src="https://openhospitality.network/assets/img/logo.png"
+            title="Open Hospitality Network"
+            alt="Open Hospitality Network logo"
+            className={styles.logo}
+          />
+          <div>Open Hospitality Network</div>
+        </a>
+        <span className={styles.plus}>+</span>
+        <a href="https://solidproject.org" className={styles.project}>
+          <img
+            src="https://avatars3.githubusercontent.com/u/14262490?v=3&s=200"
+            title="Solid Project"
+            alt="Solid Project logo"
+            className={styles.logo}
+          />
+          <div>Solid Project</div>
+        </a>
+      </div>
+      {/*<!--As a member, you own your data. In the future, you'll be able to
+          connect with other similar communities in the greater hospitality
+  exchange network.-->*/}
+      {/*<ButtonLink tertiary to="about">
         Read more
-      </ButtonLink>
+</ButtonLink>*/}
+      <div className={styles.spacer} />
+      <footer className={styles.footer}>
+        Visit our project spaces to{' '}
+        <a href="https://matrix.to/#/#ohn:matrix.org">
+          ask a question or join the team
+        </a>
+        ,{' '}
+        <a href="https://github.com/openHospitalityNetwork/sleepy.bike">
+          view source code
+        </a>{' '}
+        or <a href="https://opencollective.com/ohn">support us financially</a>.
+      </footer>
     </div>
   )
 }


### PR DESCRIPTION
This should give people the most basic idea what the project is about

It should also show more relevant information in search engines

Coauthored by @mariha and @mrkvon 

![image](https://github.com/OpenHospitalityNetwork/sleepy.bike/assets/7449720/89dd7791-69d4-4376-b93f-8209d38d3fcf)