### PR TITLE
Shorten the project description for search engines

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Sleepy Bike is a community of bicycle touring travellers and those who want to host them. It's decentralized. Members own their data and will be able to connect with other similar communities in the greater hospitality exchange network."
+      content="Sleepy Bike is a community of bicycle touring travellers and those who want to host them. It's decentralized, and members own their data."
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--

--- a/src/pages/UnauthenticatedHome.module.scss
+++ b/src/pages/UnauthenticatedHome.module.scss
@@ -28,21 +28,26 @@
     gap: 1rem;
     text-align: center;
 
-    .project {
+    .project,
+    .connection {
       display: grid;
-      grid-template-rows: 2fr 1fr;
+      grid-template-rows: 1fr 1fr;
       align-items: start;
       justify-items: center;
-      gap: 1rem;
+      gap: 0.5rem;
 
       .logo {
         height: 6rem;
         width: 6rem;
+        object-fit: contain;
       }
     }
 
     .plus {
       font-size: 3rem;
+      height: 6rem;
+      display: flex;
+      align-items: center;
     }
   }
 

--- a/src/pages/UnauthenticatedHome.tsx
+++ b/src/pages/UnauthenticatedHome.tsx
@@ -21,7 +21,10 @@ export const UnauthenticatedHome = () => {
           />
           <div>Open Hospitality Network</div>
         </a>
-        <span className={styles.plus}>+</span>
+        <span className={styles.connection}>
+          <span className={styles.plus}>+</span>
+          <span />
+        </span>
         <a href="https://solidproject.org" className={styles.project}>
           <img
             src="https://avatars3.githubusercontent.com/u/14262490?v=3&s=200"


### PR DESCRIPTION
Also improve layout of landing page logos on tiny screens

The project description was too long and search engine cut it. We removed the part describing future, which doesn't show in search results of major search engine anyways.

![image](https://github.com/OpenHospitalityNetwork/sleepy.bike/assets/7449720/8d4234b1-b027-481e-a30c-754415563bc3)
