### PR TITLE
Add mastodon handler to the frontpage/footer.

### DIFF
--- a/src/pages/UnauthenticatedHome.tsx
+++ b/src/pages/UnauthenticatedHome.tsx
@@ -55,11 +55,11 @@ export const UnauthenticatedHome = () => {
         </a>{' '}
         or <a href="https://opencollective.com/ohn">support us financially</a>.
         <br />
-        Follow us on{' '}
+        Follow us in the{' '}
         <a rel="me" href="https://floss.social/@sleepybike">
-          mastodon
+          Fediverse
         </a>{' '}
-        or{' '}
+        or on{' '}
         <a rel="me" href="https://www.facebook.com/SleepyBikePage/">
           Facebook
         </a>.

--- a/src/pages/UnauthenticatedHome.tsx
+++ b/src/pages/UnauthenticatedHome.tsx
@@ -62,7 +62,8 @@ export const UnauthenticatedHome = () => {
         or on{' '}
         <a rel="me" href="https://www.facebook.com/SleepyBikePage/">
           Facebook
-        </a>.
+        </a>
+        .
       </footer>
     </div>
   )

--- a/src/pages/UnauthenticatedHome.tsx
+++ b/src/pages/UnauthenticatedHome.tsx
@@ -62,7 +62,7 @@ export const UnauthenticatedHome = () => {
         or{' '}
         <a rel="me" href="https://www.facebook.com/SleepyBikePage/">
           Facebook
-        </a>
+        </a>.
       </footer>
     </div>
   )

--- a/src/pages/UnauthenticatedHome.tsx
+++ b/src/pages/UnauthenticatedHome.tsx
@@ -54,6 +54,15 @@ export const UnauthenticatedHome = () => {
           view source code
         </a>{' '}
         or <a href="https://opencollective.com/ohn">support us financially</a>.
+        <br />
+        Follow us on{' '}
+        <a rel="me" href="https://floss.social/@sleepybike">
+          mastodon
+        </a>{' '}
+        or{' '}
+        <a rel="me" href="https://www.facebook.com/SleepyBikePage/">
+          Facebook
+        </a>
       </footer>
     </div>
   )


### PR DESCRIPTION
Fixes #56.

It should add a line `Follow us on mastodon or Facebook` at the bottom of the page. 

I run linter but couldn't run the app locally. I need to spend some time on setting up the environment.