### PR TITLE
Add mastodon handler link to index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,10 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+
+    <!-- verification for Mastodon -->
+    <link rel="me" href="https://floss.social/@sleepybike" />
+
     <title>Sleepy Bike</title>
 
     <!-- Start Single Page Apps for GitHub Pages -->


### PR DESCRIPTION
Second attempt to verify sleepy.bike page on Mastodon. This time, the link should be loaded even without executing JavaScript.

Fixes #56 