### PR TITLE
Integrate email notifications

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,8 @@ jobs:
         env:
           REACT_APP_COMMUNITY: ${{ vars.COMMUNITY }}
           REACT_APP_COMMUNITY_CONTAINER: ${{ vars.COMMUNITY_CONTAINER }}
+          REACT_APP_EMAIL_NOTIFICATIONS_SERVICE: ${{ vars.EMAIL_NOTIFICATIONS_SERVICE }}
+          REACT_APP_EMAIL_NOTIFICATIONS_IDENTITY: ${{ vars.EMAIL_NOTIFICATIONS_IDENTITY }}
 
       - name: Upload production-ready build files
         uses: actions/upload-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
           CYPRESS_COMMUNITY: http://localhost:4000/test-community/community#us'
           CYPRESS_cssUrl: http://localhost:4000
           REACT_APP_COMMUNITY: http://localhost:4000/test-community/community#us'
+          REACT_APP_EMAIL_NOTIFICATIONS_SERVICE: http://localhost:3005
+          REACT_APP_EMAIL_NOTIFICATIONS_IDENTITY: https://example.com/bot/profile/card#me
           BROWSER: none
         with:
           start: yarn start, yarn community-solid-server -p 4000 -l error

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     // setupNodeEvents(on, config) {
     //   // implement node event listeners here
     // },
-    defaultCommandTimeout: 10000,
+    defaultCommandTimeout: 15000,
     // set mobile viewport as default, because we make mobile-first interface
     // this is screen size of iPhone 11, apparently a popular phone
     viewportWidth: 375,

--- a/cypress/e2e/accommodation.cy.ts
+++ b/cypress/e2e/accommodation.cy.ts
@@ -1,45 +1,30 @@
-import { UserConfig } from '../support/css-authentication'
-import { CommunityConfig } from '../support/setup'
-
-const profile = {
-  name: 'Test Name',
-  description: {
-    // we wanted to test multiline description, but cypress wasn't detecting it
-    en: 'Hello! This is description in English.',
-  },
-}
+import { Person } from '../support/commands'
 
 describe('accommodations offered by person', () => {
   // create and setup community and profiles
   beforeEach(() => {
-    cy.createRandomAccount().as('me')
-    cy.get<CommunityConfig>('@community').then(community => {
-      cy.get<UserConfig>('@me').then(user => {
-        cy.setupPod(user, community)
-          .as('setupMe')
-          .then(setup => {
-            cy.setProfileData(user, setup, profile)
-            cy.addAccommodation(user, setup, {
-              description: { en: 'accommodation 1' },
-              location: [50, 16],
-            })
-            cy.addAccommodation(user, setup, {
-              description: { en: 'accommodation 2' },
-              location: [51, 17],
-            })
-            cy.addAccommodation(user, setup, {
-              description: { en: 'accommodation 3' },
-              location: [52, 18],
-            })
-          })
+    cy.createPerson().as('me')
+    cy.get<Person>('@me').then(person => {
+      cy.addAccommodation(person, {
+        description: { en: 'accommodation 1' },
+        location: [50, 16],
+      })
+      cy.addAccommodation(person, {
+        description: { en: 'accommodation 2' },
+        location: [51, 17],
+      })
+      cy.addAccommodation(person, {
+        description: { en: 'accommodation 3' },
+        location: [52, 18],
       })
     })
   })
 
   // sign in
   beforeEach(() => {
-    cy.get<UserConfig>('@me').then(user => {
-      cy.login(user)
+    cy.get<Person>('@me').then(person => {
+      cy.stubMailer({ person })
+      cy.login(person)
     })
   })
 

--- a/cypress/e2e/contacts.cy.ts
+++ b/cypress/e2e/contacts.cy.ts
@@ -45,7 +45,10 @@ describe("person's contacts", () => {
 
   // sign in
   beforeEach(() => {
-    cy.get<Person>('@me').then(me => cy.login(me))
+    cy.get<Person>('@me').then(me => {
+      cy.stubMailer({ person: me })
+      cy.login(me)
+    })
   })
 
   it('should show my contacts, including unconfirmed and pending')

--- a/cypress/e2e/contacts.cy.ts
+++ b/cypress/e2e/contacts.cy.ts
@@ -107,6 +107,7 @@ describe("person's contacts", () => {
 
         // test that other person can confirm
         cy.logout()
+        cy.stubMailer({ person })
         cy.login(person)
         cy.visit(`/profile/${encodeURIComponent(me.webId)}`)
         cy.contains('button', 'See contact invitation', {

--- a/cypress/e2e/login.cy.ts
+++ b/cypress/e2e/login.cy.ts
@@ -3,6 +3,12 @@ import { UserConfig } from '../support/css-authentication'
 describe('Sign in to the app', () => {
   beforeEach(() => {
     cy.createRandomAccount().as('user1')
+    cy.get<UserConfig>('@user1').then(user => {
+      cy.stubMailer({
+        person: { ...user, inbox: `${user.podUrl}inbox/` },
+        integrated: false,
+      })
+    })
   })
 
   it('should sign in with identity provider', () => {

--- a/cypress/e2e/map.cy.ts
+++ b/cypress/e2e/map.cy.ts
@@ -1,40 +1,33 @@
 import { range } from 'lodash'
+import { Person } from '../support/commands'
 import { UserConfig } from '../support/css-authentication'
-import { AccommodationConfig, CommunityConfig } from '../support/setup'
+import { AccommodationConfig } from '../support/setup'
 
 const users = range(10).map(i => (i === 0 ? 'me' : `user${i}`))
 
 describe('Map of accommodation offers', () => {
-  // create and setup community and profiles
+  // create people and their accommodations
   beforeEach(() => {
-    cy.get<CommunityConfig>('@community').then(community => {
-      users.forEach((tag, i) => {
-        cy.createRandomAccount().as(tag)
-        cy.get<UserConfig>(`@${tag}`).then(user => {
-          cy.setupPod(user, community)
-            .as(`${tag}Setup`)
-            .then(setup => {
-              cy.setProfileData(user, setup, {
-                name: `Name ${i}`,
-                description: { en: `This is English description ${i}` },
-              })
-              cy.addAccommodation(user, setup, {
-                description: { en: `accommodation of ${tag}` },
-                location:
-                  i % 2 === 1
-                    ? [5 * i + 5, 10 * i - 10]
-                    : [-10 * i + 40, 5 * i - 90],
-              }).as(`${tag}Accommodation`)
-            })
-        })
+    users.forEach((tag, i) => {
+      cy.createPerson({
+        name: `Name ${i}`,
+        description: { en: `This is English description ${i}` },
+      }).as(tag)
+      cy.get<Person>(`@${tag}`).then(person => {
+        cy.addAccommodation(person, {
+          description: { en: `accommodation of ${tag}` },
+          location:
+            i % 2 === 1 ? [5 * i + 5, 10 * i - 10] : [-10 * i + 40, 5 * i - 90],
+        }).as(`${tag}Accommodation`)
       })
     })
   })
 
   // sign in
   beforeEach(() => {
-    cy.get<UserConfig>('@me').then(user => {
-      cy.login(user)
+    cy.get<Person>('@me').then(person => {
+      cy.stubMailer({ person })
+      cy.login(person)
     })
   })
 

--- a/cypress/e2e/profile.cy.ts
+++ b/cypress/e2e/profile.cy.ts
@@ -1,5 +1,5 @@
+import { Person } from '../support/commands'
 import { UserConfig } from '../support/css-authentication'
-import { CommunityConfig } from '../support/setup'
 
 const profile = {
   name: 'Test Name',
@@ -17,26 +17,15 @@ const otherProfile = {
 describe('view profile', () => {
   // create and setup community and profiles
   beforeEach(() => {
-    cy.createRandomAccount().as('me')
-    cy.createRandomAccount().as('otherPerson')
-    cy.get<CommunityConfig>('@community').then(community => {
-      cy.get<UserConfig>('@me').then(user => {
-        cy.setupPod(user, community).then(setup => {
-          cy.setProfileData(user, setup, profile)
-        })
-      })
-      cy.get<UserConfig>('@otherPerson').then(user => {
-        cy.setupPod(user, community).then(setup => {
-          cy.setProfileData(user, setup, otherProfile)
-        })
-      })
-    })
+    cy.createPerson(profile).as('me')
+    cy.createPerson(otherProfile).as('otherPerson')
   })
 
   // sign in
   beforeEach(() => {
-    cy.get<UserConfig>('@me').then(user => {
-      cy.login(user)
+    cy.get<Person>('@me').then(person => {
+      cy.stubMailer({ person })
+      cy.login(person)
     })
   })
 

--- a/cypress/e2e/setup.cy.ts
+++ b/cypress/e2e/setup.cy.ts
@@ -111,7 +111,9 @@ describe('Setup Solid pod', () => {
           person: { ...user, inbox: `${user.podUrl}inbox/` },
           verified: false,
         })
-        cy.intercept('POST', 'http://localhost:3005/inbox').as('integration')
+        cy.intercept('POST', 'http://localhost:3005/inbox', {}).as(
+          'integration',
+        )
         cy.contains('button', 'Continue!').click()
         cy.contains('verify your email')
         cy.wait('@integration')
@@ -153,12 +155,14 @@ describe('Setup Solid pod', () => {
         cy.get('input[type="email"][placeholder="Your email"]')
           .should('exist')
           .type('asdf@example.com')
-        cy.intercept('POST', 'http://localhost:3005/inbox').as('integration')
+        cy.intercept('POST', 'http://localhost:3005/inbox', {}).as(
+          'integration',
+        )
         // here we respond differently than real test (integration would be unverified)
         // but we respond it verified, to be able to check that everything was established and we entered the app
         cy.stubMailer({ person: { ...user, inbox: `${user.podUrl}inbox/` } })
         cy.contains('button', 'Continue!').click()
-        cy.wait('@addUserToCommunity', { timeout: 10000 })
+        cy.wait('@addUserToCommunity', { timeout: 15000 })
         cy.wait('@integration')
           .its('request.body')
           .should('deep.equal', {

--- a/cypress/e2e/setup.cy.ts
+++ b/cypress/e2e/setup.cy.ts
@@ -97,6 +97,11 @@ describe('Setup Solid pod', () => {
 
   context('email notifications are not integrated', () => {
     beforeEach(setupPod())
+
+    it('should allow custom email notifications service')
+
+    it('should make inbox readable for email notifications service identity')
+
     it('should ask for email and integrate notifications', () => {
       cy.get<UserConfig>('@user1').then(user => {
         cy.stubMailer({

--- a/cypress/e2e/threads.cy.ts
+++ b/cypress/e2e/threads.cy.ts
@@ -1,19 +1,20 @@
 import { Person } from '../support/commands'
-import { CommunityConfig } from '../support/setup'
 
 describe('threads (list of conversations)', () => {
   beforeEach(() => {
     // create and setup people
-    cy.get<CommunityConfig>('@community').then(community => {
-      ;['me', 'person1', 'person2'].forEach((tag, i) => {
-        cy.createPerson(
-          {
-            name: `Name ${i}`,
-            description: { en: `This is English description ${i}` },
-          },
-          community,
-        ).as(tag)
-      })
+    ;['me', 'person1', 'person2'].forEach((tag, i) => {
+      cy.createPerson({
+        name: `Name ${i}`,
+        description: { en: `This is English description ${i}` },
+      }).as(tag)
+    })
+  })
+
+  // stub mailer
+  beforeEach(() => {
+    cy.get<Person>('@me').then(me => {
+      cy.stubMailer({ person: me })
     })
   })
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -57,6 +57,7 @@ import {
   setStorage,
   setupCommunity,
   setupPod,
+  stubMailer,
 } from './setup'
 import { ContactNotification, saveContacts } from './setup/contacts'
 import { Conversation, createConversation } from './setup/messages'
@@ -96,8 +97,7 @@ declare global {
         profile: Profile,
       ): void
       addAccommodation(
-        user: UserConfig,
-        setup: SetupConfig,
+        person: Person,
         accommodation: AccommodationData,
       ): Cypress.Chainable<AccommodationConfig>
       /**
@@ -129,6 +129,12 @@ declare global {
         contacts: Person[]
         notifications?: (ContactNotification | number)[]
         doc?: string
+      }): void
+      stubMailer(config: {
+        person: Pick<Person, 'webId' | 'inbox'>
+        mailer?: string
+        integrated?: boolean
+        verified?: boolean
       }): void
     }
   }
@@ -272,6 +278,7 @@ Cypress.Commands.add('setStorage', setStorage)
 Cypress.Commands.add('setProfileData', setProfileData)
 Cypress.Commands.add('addAccommodation', addAccommodation)
 Cypress.Commands.add('createConversation', createConversation)
+Cypress.Commands.add('stubMailer', stubMailer)
 
 /**
 Some code is copied from solidcryptpad repository

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -6,6 +6,8 @@ You'll find [configurable options](#options) for the application here. We use en
 
 - `REACT_APP_COMMUNITY` - URI of the community
 - `REACT_APP_COMMUNITY_CONTAINER` - name of folder in which to store person's data of this community
+- `REACT_APP_EMAIL_NOTIFICATIONS_SERVICE` - server providing email notifications service along the lines of [solid-email-notifications](https://github.com/openHospitalityNetwork/solid-email-notifications); provide base url without trailing slash; notifications will be disabled if left empty
+- `REACT_APP_EMAIL_NOTIFICATIONS_IDENTITY` - identity of the email notifications service; app will allow this identity to read person's inbox
 - [default CreateReactApp options](https://create-react-app.dev/docs/advanced-configuration)
 
 ## Usage
@@ -34,6 +36,8 @@ Have a look in [deployment workflow](../.github/workflows/deploy.yml) to see how
 
 - `COMMUNITY`
 - `COMMUNITY_CONTAINER`
+- `EMAIL_NOTIFICATIONS_SERVICE`
+- `EMAIL_NOTIFICATIONS_IDENTITY`
 - see [deployment workflow](../.github/workflows/deploy.yml) for more
 
 ## Adding a new option

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,json,md,css,scss}\" package.json \"cypress/**/*.{ts,tsx,json,md,css,scss}\" \"**/*.{yml,yaml,md,json,html}\"",
     "build:ldo": "ldo build --input src/shapes --output src/ldo",
     "postbuild:ldo": "yarn format",
-    "cy:dev": "concurrently --kill-others \"BROWSER=none REACT_APP_COMMUNITY=http://localhost:4000/test-community/community#us yarn start\" \"community-solid-server -p 4000 -l error\" \"CYPRESS_COMMUNITY=\\\"http://localhost:4000/test-community/community#us\\\" cypress open\""
+    "cy:dev": "concurrently --kill-others \"BROWSER=none REACT_APP_COMMUNITY=http://localhost:4000/test-community/community#us REACT_APP_EMAIL_NOTIFICATIONS_SERVICE=http://localhost:3005 REACT_APP_EMAIL_NOTIFICATIONS_IDENTITY=https://example.com/bot/profile/card#me yarn start\" \"community-solid-server -p 4000 -l error\" \"CYPRESS_COMMUNITY=\\\"http://localhost:4000/test-community/community#us\\\" cypress open\""
   },
   "browserslist": {
     "production": [

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -14,6 +14,21 @@ export const communityId =
 export const communityContainer =
   process.env.REACT_APP_COMMUNITY_CONTAINER || 'dev-sleepy-bike'
 
+/**
+ * Service for email notifications
+ * Should work along the lines of https://github.com/openHospitalityNetwork/solid-email-notifications
+ */
+export const emailNotificationsService =
+  process.env.REACT_APP_EMAIL_NOTIFICATIONS_SERVICE ?? ''
+// TODO maybe we'll fetch the identity directly from the mailer, when it supports that option, so the setup will be less complicated
+export const emailNotificationsIdentity =
+  process.env.REACT_APP_EMAIL_NOTIFICATIONS_IDENTITY ?? ''
+
+if (emailNotificationsService && !emailNotificationsIdentity)
+  throw new Error(
+    'Please provide webId of email notifications service in environment variable REACT_APP_EMAIL_NOTIFICATIONS_IDENTITY',
+  )
+
 export const wikidataLDF = 'https://query.wikidata.org/bigdata/ldf'
 
 export const oidcIssuers = [

--- a/src/hooks/data/useCheckSetup.ts
+++ b/src/hooks/data/useCheckSetup.ts
@@ -97,7 +97,7 @@ export const useHospexDocumentSetup = (userId: URI, communityId: URI) => {
 
 export const useCheckEmailNotifications = (inbox: URI, mailer: string) => {
   const checkMailerIntegration = useCallback(async () => {
-    if (!mailer) throw new Error('Mailer not set up')
+    if (!mailer) return 'mailer not set up'
 
     const response = await fetch(`${mailer}/status`)
     if (!response.ok) {
@@ -106,11 +106,14 @@ export const useCheckEmailNotifications = (inbox: URI, mailer: string) => {
     return response.json()
   }, [mailer])
 
-  const { isLoading, data, isError, error } = useQuery<{
-    integrations: { object: URI; target: URI; verified: boolean }[]
-  }>(['mailerIntegration'], checkMailerIntegration)
+  const { isLoading, data } = useQuery<
+    | {
+        integrations: { object: URI; target: URI; verified: boolean }[]
+      }
+    | 'mailer not set up'
+  >(['mailerIntegration'], checkMailerIntegration)
 
-  if (isError && (error as Error).message === 'Mailer not set up') return true
+  if (data === 'mailer not set up') return true
 
   if (isLoading || !data) return undefined
   const integrations = data.integrations.filter(i => i.object === inbox)

--- a/src/hooks/data/useCheckSetup.ts
+++ b/src/hooks/data/useCheckSetup.ts
@@ -95,18 +95,22 @@ export const useHospexDocumentSetup = (userId: URI, communityId: URI) => {
   } as const
 }
 
-export const useCheckEmailNotifications = (inbox: URI) => {
+export const useCheckEmailNotifications = (inbox: URI, mailer: string) => {
   const checkMailerIntegration = useCallback(async () => {
-    const response = await fetch('http://localhost:3005/status')
+    if (!mailer) throw new Error('Mailer not set up')
+
+    const response = await fetch(`${mailer}/status`)
     if (!response.ok) {
       throw new Error('Network response was not ok')
     }
     return response.json()
-  }, [])
+  }, [mailer])
 
-  const { isLoading, data } = useQuery<{
+  const { isLoading, data, isError, error } = useQuery<{
     integrations: { object: URI; target: URI; verified: boolean }[]
   }>(['mailerIntegration'], checkMailerIntegration)
+
+  if (isError && (error as Error).message === 'Mailer not set up') return true
 
   if (isLoading || !data) return undefined
   const integrations = data.integrations.filter(i => i.object === inbox)

--- a/src/hooks/data/useSetupHospex.ts
+++ b/src/hooks/data/useSetupHospex.ts
@@ -367,12 +367,13 @@ const useInitEmailNotifications = () => {
       headers: { 'content-type': 'application/ld+json' },
       body: JSON.stringify(requestData),
     })
-    return response.json() // Assuming the response is in JSON format
+
+    if (!response.ok) throw new Error('not ok!')
   }
 
   const queryClient = useQueryClient()
 
-  const { mutate, isLoading, isError, isSuccess } = useMutation({
+  const { mutate } = useMutation({
     mutationFn: addActivity,
     onSuccess: () => {
       queryClient.invalidateQueries(['mailerIntegration'])

--- a/src/hooks/data/useSetupHospex.ts
+++ b/src/hooks/data/useSetupHospex.ts
@@ -1,6 +1,10 @@
 import { fetch } from '@inrupt/solid-client-authn-browser'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { communityId } from 'config'
+import {
+  communityId,
+  emailNotificationsIdentity,
+  emailNotificationsService,
+} from 'config'
 import { useAuth } from 'hooks/useAuth'
 import {
   HospexProfileShapeType,
@@ -362,7 +366,7 @@ const useCreateInbox = () => {
 const useInitEmailNotifications = () => {
   // Define a mutation function that will handle the API request
   const addActivity = async (requestData: any) => {
-    const response = await fetch(`http://localhost:3005/inbox`, {
+    const response = await fetch(`${emailNotificationsService}/inbox`, {
       method: 'post',
       headers: { 'content-type': 'application/ld+json' },
       body: JSON.stringify(requestData),
@@ -417,7 +421,7 @@ const useInitEmailNotifications = () => {
           ldo['@id'] = inboxAcl + '#read'
           ldo.type = { '@id': 'Authorization' }
 
-          ldo.agent = [{ '@id': 'http://localhost:3456/bot/profile/card#me' }]
+          ldo.agent = [{ '@id': emailNotificationsIdentity }]
           ldo.accessTo = [{ '@id': inbox }]
           ldo.default = { '@id': inbox }
           ldo.mode = [{ '@id': acl.Read }]

--- a/src/hooks/data/useSetupHospex.ts
+++ b/src/hooks/data/useSetupHospex.ts
@@ -1,4 +1,7 @@
+import { fetch } from '@inrupt/solid-client-authn-browser'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { communityId } from 'config'
+import { useAuth } from 'hooks/useAuth'
 import {
   HospexProfileShapeType,
   PrivateTypeIndexShapeType,
@@ -24,12 +27,14 @@ export type SetupTask =
   | 'createPrivateTypeIndex'
   | 'createInbox'
   | 'createHospexProfile'
+  | 'integrateEmailNotifications'
 export type SetupSettings = {
   person: URI
   publicTypeIndex: URI
   privateTypeIndex: URI
   inbox: URI
   hospexDocument: URI
+  email: string
 }
 
 export const useSetupHospex = () => {
@@ -38,6 +43,9 @@ export const useSetupHospex = () => {
   const createInbox = useCreateInbox()
   const createHospexProfile = useCreateHospexProfile()
   const saveTypeRegistration = useSaveTypeRegistration()
+  const initEmailNotifications = useInitEmailNotifications()
+
+  const { webId } = useAuth()
 
   // TODO add options so users can have a choice
   return useCallback(
@@ -49,6 +57,7 @@ export const useSetupHospex = () => {
         privateTypeIndex,
         hospexDocument,
         inbox,
+        email,
       }: SetupSettings,
     ) => {
       // create personal hospex document at hospex/{communityContainer}/card
@@ -92,13 +101,18 @@ export const useSetupHospex = () => {
           type: hospex.PersonalHospexDocument,
           location: hospexDocument,
         })
+
+      if (tasks.includes('integrateEmailNotifications'))
+        await initEmailNotifications({ email, inbox, webId: webId as string })
     },
     [
       createHospexProfile,
       createInbox,
       createPrivateTypeIndex,
       createPublicTypeIndex,
+      initEmailNotifications,
       saveTypeRegistration,
+      webId,
     ],
   )
 }
@@ -342,5 +356,79 @@ const useCreateInbox = () => {
       })
     },
     [createAclMutation, createContainerMutation, updateMutation],
+  )
+}
+
+const useInitEmailNotifications = () => {
+  // Define a mutation function that will handle the API request
+  const addActivity = async (requestData: any) => {
+    const response = await fetch(`http://localhost:3005/inbox`, {
+      method: 'post',
+      headers: { 'content-type': 'application/ld+json' },
+      body: JSON.stringify(requestData),
+    })
+    return response.json() // Assuming the response is in JSON format
+  }
+
+  const queryClient = useQueryClient()
+
+  const { mutate, isLoading, isError, isSuccess } = useMutation({
+    mutationFn: addActivity,
+    onSuccess: () => {
+      queryClient.invalidateQueries(['mailerIntegration'])
+    },
+  })
+
+  const initializeIntegration = useCallback(
+    ({ webId, inbox, email }: { webId: URI; inbox: URI; email: string }) => {
+      const requestData = {
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        '@id': '',
+        '@type': 'Add',
+        actor: webId,
+        object: inbox,
+        target: email,
+      }
+
+      mutate(requestData)
+    },
+    [mutate],
+  )
+
+  const updateAclMutation = useUpdateLdoDocument(AuthorizationShapeType)
+
+  return useCallback(
+    async ({
+      email,
+      inbox,
+      webId,
+    }: {
+      webId: URI
+      inbox: URI
+      email: string
+    }) => {
+      // give mailer read access to inbox
+      const inboxAcl = await getAcl(inbox)
+      await updateAclMutation.mutateAsync({
+        uri: inboxAcl,
+        subject: inboxAcl + '#read',
+        transform: ldo => {
+          ldo['@id'] = inboxAcl + '#read'
+          ldo.type = { '@id': 'Authorization' }
+
+          ldo.agent = [{ '@id': 'http://localhost:3456/bot/profile/card#me' }]
+          ldo.accessTo = [{ '@id': inbox }]
+          ldo.default = { '@id': inbox }
+          ldo.mode = [{ '@id': acl.Read }]
+        },
+      })
+      // initialize integration
+      await initializeIntegration({
+        email,
+        inbox,
+        webId,
+      })
+    },
+    [initializeIntegration, updateAclMutation],
   )
 }

--- a/src/pages/HospexSetup.tsx
+++ b/src/pages/HospexSetup.tsx
@@ -118,9 +118,10 @@ export const HospexSetup = ({
         <li>
           {!isEmailNotifications && (
             <div>
-              setup email notifications{' '}
+              Setup email notifications{' '}
               <input
                 type="email"
+                placeholder="Your email"
                 value={email}
                 onChange={e => setEmail(e.target.value)}
               />

--- a/src/pages/HospexSetup.tsx
+++ b/src/pages/HospexSetup.tsx
@@ -19,6 +19,7 @@ export const HospexSetup = ({
   isPrivateTypeIndex,
   isHospexProfile,
   isInbox,
+  isEmailNotifications,
   personalHospexDocuments,
   publicTypeIndexes,
   privateTypeIndexes,
@@ -29,6 +30,7 @@ export const HospexSetup = ({
   isPublicTypeIndex: boolean
   isPrivateTypeIndex: boolean
   isInbox: boolean
+  isEmailNotifications: boolean | 'unverified'
   personalHospexDocuments: URI[]
   publicTypeIndexes: URI[]
   privateTypeIndexes: URI[]
@@ -40,20 +42,22 @@ export const HospexSetup = ({
   const community = useReadCommunity(communityId)
   const joinGroup = useJoinGroup()
   const [isSaving, setIsSaving] = useState(false)
+  const [email, setEmail] = useState('')
   const handleClickSetup = async () => {
     setIsSaving(true)
     if (
       !isPublicTypeIndex ||
       !isPrivateTypeIndex ||
       !isHospexProfile ||
-      !isInbox
+      !isInbox ||
+      !isEmailNotifications
     ) {
       const tasks: SetupTask[] = []
       if (!isPublicTypeIndex) tasks.push('createPublicTypeIndex')
       if (!isPrivateTypeIndex) tasks.push('createPrivateTypeIndex')
       if (!isHospexProfile) tasks.push('createHospexProfile')
       if (!isInbox) tasks.push('createInbox')
-
+      if (!isEmailNotifications) tasks.push('integrateEmailNotifications')
       if (!auth.webId) throw new Error('not signed in')
       if (isPublicTypeIndex && !publicTypeIndexes[0])
         throw new Error('existing public type index not found')
@@ -71,6 +75,7 @@ export const HospexSetup = ({
         hospexDocument: isHospexProfile
           ? personalHospexDocuments[0]
           : `${storage}hospex/${communityContainer}/card`,
+        email,
       }
       await setupHospex(tasks, settings)
     }
@@ -109,6 +114,21 @@ export const HospexSetup = ({
           {!isHospexProfile &&
             'setup hospex document and storage ' +
               `${storage}hospex/${communityContainer}/card`}
+        </li>
+        <li>
+          {!isEmailNotifications && (
+            <div>
+              setup email notifications{' '}
+              <input
+                type="email"
+                value={email}
+                onChange={e => setEmail(e.target.value)}
+              />
+            </div>
+          )}
+          {isEmailNotifications === 'unverified' && (
+            <div>Please verify your email</div>
+          )}
         </li>
       </ul>
       <Button primary onClick={() => handleClickSetup()}>

--- a/src/pages/SetupOutlet.tsx
+++ b/src/pages/SetupOutlet.tsx
@@ -1,6 +1,6 @@
 import { useAppSelector } from 'app/hooks'
 import { Loading } from 'components'
-import { communityId } from 'config'
+import { communityId, emailNotificationsService } from 'config'
 import { selectAuth } from 'features/auth/authSlice'
 import {
   useCheckEmailNotifications,
@@ -22,7 +22,10 @@ export const SetupOutlet = () => {
   ])
 
   // set up email
-  const isEmailNotifications = useCheckEmailNotifications(setupCheck.inboxes[0])
+  const isEmailNotifications = useCheckEmailNotifications(
+    setupCheck.inboxes[0],
+    emailNotificationsService,
+  )
 
   const isEverythingSetUp =
     Object.values(setupCheck).every(v => v) && isEmailNotifications === true

--- a/src/pages/SetupOutlet.tsx
+++ b/src/pages/SetupOutlet.tsx
@@ -32,6 +32,9 @@ export const SetupOutlet = () => {
   const checks = Object.entries(tasks)
     .filter(([, value]) => value === undefined)
     .map(([key]) => key)
+  if (isEmailNotifications === undefined) {
+    checks.push('isEmailNotifications')
+  }
   if (
     Object.values(setupCheck).some(a => a === undefined) ||
     isEmailNotifications === undefined

--- a/src/pages/SetupOutlet.tsx
+++ b/src/pages/SetupOutlet.tsx
@@ -2,7 +2,10 @@ import { useAppSelector } from 'app/hooks'
 import { Loading } from 'components'
 import { communityId } from 'config'
 import { selectAuth } from 'features/auth/authSlice'
-import { useCheckSetup } from 'hooks/data/useCheckSetup'
+import {
+  useCheckEmailNotifications,
+  useCheckSetup,
+} from 'hooks/data/useCheckSetup'
 import { omit } from 'lodash'
 import { Outlet } from 'react-router-dom'
 import { NonUndefined } from 'utility-types'
@@ -18,17 +21,29 @@ export const SetupOutlet = () => {
     'personalHospexDocuments',
   ])
 
-  const isEverythingSetUp = Object.values(setupCheck).every(v => v)
+  // set up email
+  const isEmailNotifications = useCheckEmailNotifications(setupCheck.inboxes[0])
+
+  const isEverythingSetUp =
+    Object.values(setupCheck).every(v => v) && isEmailNotifications === true
 
   if (isEverythingSetUp) return <Outlet />
 
   const checks = Object.entries(tasks)
     .filter(([, value]) => value === undefined)
     .map(([key]) => key)
-  if (Object.values(setupCheck).some(a => a === undefined))
+  if (
+    Object.values(setupCheck).some(a => a === undefined) ||
+    isEmailNotifications === undefined
+  )
     return <Loading>Checking {checks.join(', ')}</Loading>
 
-  return <HospexSetup {...(setupCheck as DefinedProps<typeof setupCheck>)} />
+  return (
+    <HospexSetup
+      {...(setupCheck as DefinedProps<typeof setupCheck>)}
+      isEmailNotifications={isEmailNotifications}
+    />
+  )
 }
 
 type DefinedProps<T extends { [key: string]: unknown }> = {


### PR DESCRIPTION
Email notifications are sent via solid-email-notifications service
https://github.com/openHospitalityNetwork/solid-email-notifications

There are 2 variables to set:

- `REACT_APP_EMAIL_NOTIFICATIONS_SERVICE` - the base url of the service
- `REACT_APP_EMAIL_NOTIFICATIONS_IDENTITY` - the identity of the mailer, the app gives it read access to person's inbox

If the first one is left empty, no notifications are required

It should be ok to merge. Nothing will change until we fill the variables above.

The service is already live at https://service.notifications.sleepy.bike/

Fixes ???

Possible follow-up:

- make the initial setup page nicer
- make it possible to select custom notifier service
- allow for re-integrating and/or re-sending email when you type wrong email, or verification email doesn't arrive
- change email
- unsubscribe
- store email in person's pod, not in mailer's database (probably in a settings file, like /hospex/settings.ttl)