### PR TITLE
Allow joining multiple communities

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
         uses: cypress-io/github-action@v5
         env:
           CYPRESS_COMMUNITY: http://localhost:4000/test-community/community#us'
+          CYPRESS_OTHER_COMMUNITY: http://localhost:4000/other-community/community#us'
           CYPRESS_cssUrl: http://localhost:4000
           REACT_APP_COMMUNITY: http://localhost:4000/test-community/community#us'
           REACT_APP_EMAIL_NOTIFICATIONS_SERVICE: http://localhost:3005

--- a/cypress/e2e/setup.cy.ts
+++ b/cypress/e2e/setup.cy.ts
@@ -91,10 +91,6 @@ describe('Setup Solid pod', () => {
     })
   })
 
-  context("person's inbox is missing", () => {
-    it('should create inbox')
-  })
-
   context('email notifications are not integrated', () => {
     beforeEach(setupPod())
 
@@ -180,6 +176,31 @@ describe('Setup Solid pod', () => {
           })
         cy.contains('a', 'travel')
       })
+    })
+  })
+
+  context('person joined another community', () => {
+    beforeEach(() => {
+      cy.get<UserConfig>('@user1').then(user => {
+        cy.get<CommunityConfig>('@otherCommunity').then(community => {
+          cy.setupPod(user, community, {
+            hospexContainerName: 'other-community',
+          })
+        })
+      })
+      setupPod([
+        'personalHospexDocument',
+        'joinCommunity',
+        'publicTypeIndex',
+        'privateTypeIndex',
+        'inbox',
+      ])()
+    })
+
+    it('should join this community just fine', () => {
+      cy.get<UserConfig>('@user1').then(user => cy.login(user))
+      cy.contains('button', 'Continue!').click()
+      cy.contains('a', 'travel')
     })
   })
 })

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -87,7 +87,8 @@ declare global {
         user: UserConfig,
         community: CommunityConfig,
         options?: {
-          skip: SkipOptions[]
+          skip?: SkipOptions[]
+          hospexContainerName?: string
         },
       ): Cypress.Chainable<SetupConfig>
       setStorage(user: UserConfig): void

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -22,4 +22,7 @@ import './commands'
 // set up a community before every test
 beforeEach(() => {
   cy.setupCommunity({ community: Cypress.env('COMMUNITY') }).as('community')
+  cy.setupCommunity({ community: Cypress.env('OTHER_COMMUNITY') }).as(
+    'otherCommunity',
+  )
 })

--- a/cypress/support/setup.ts
+++ b/cypress/support/setup.ts
@@ -142,18 +142,22 @@ export type SkipOptions =
 export const setupPod = (
   user: UserConfig,
   community: CommunityConfig,
-  options?: {
-    skip: SkipOptions[]
+  {
+    skip = [],
+    hospexContainerName = 'test-community',
+  }: { skip: SkipOptions[]; hospexContainerName: string } = {
+    skip: [],
+    hospexContainerName: 'test-community',
   },
 ) => {
   const publicTypeIndexUri = `${user.podUrl}settings/publicTypeIndex.ttl`
   const privateTypeIndexUri = `${user.podUrl}settings/privateTypeIndex.ttl`
-  const hospexContainer = `${user.podUrl}hospex/test-community/`
+  const hospexContainer = `${user.podUrl}hospex/${hospexContainerName}/`
   const hospexDocument = hospexContainer + 'card'
   const inboxUri = `${user.podUrl}inbox/`
 
   // create inbox
-  if (!options?.skip.includes('inbox')) {
+  if (!skip.includes('inbox')) {
     cy.authenticatedRequest(user, {
       url: inboxUri,
       method: 'PUT',
@@ -193,7 +197,7 @@ export const setupPod = (
     })
   }
   // create public type index
-  if (!options?.skip.includes('publicTypeIndex')) {
+  if (!skip.includes('publicTypeIndex')) {
     cy.authenticatedRequest(user, {
       url: publicTypeIndexUri,
       method: 'PUT',
@@ -232,7 +236,7 @@ export const setupPod = (
     })
   }
   // create private type index
-  if (!options?.skip.includes('privateTypeIndex')) {
+  if (!skip.includes('privateTypeIndex')) {
     cy.authenticatedRequest(user, {
       url: privateTypeIndexUri,
       method: 'PUT',
@@ -263,7 +267,7 @@ export const setupPod = (
     })
   }
   // create hospex document
-  if (!options?.skip.includes('personalHospexDocument')) {
+  if (!skip.includes('personalHospexDocument')) {
     const communityUri = community.community
     cy.authenticatedRequest(user, {
       url: hospexDocument,
@@ -309,7 +313,7 @@ export const setupPod = (
   }
 
   // join community
-  if (!options?.skip.includes('joinCommunity')) {
+  if (!skip.includes('joinCommunity')) {
     cy.authenticatedRequest(user, {
       url: community.group,
       method: 'PATCH',

--- a/cypress/support/setup.ts
+++ b/cypress/support/setup.ts
@@ -145,10 +145,7 @@ export const setupPod = (
   {
     skip = [],
     hospexContainerName = 'test-community',
-  }: { skip: SkipOptions[]; hospexContainerName: string } = {
-    skip: [],
-    hospexContainerName: 'test-community',
-  },
+  }: { skip?: SkipOptions[]; hospexContainerName?: string } = {},
 ) => {
   const publicTypeIndexUri = `${user.podUrl}settings/publicTypeIndex.ttl`
   const privateTypeIndexUri = `${user.podUrl}settings/privateTypeIndex.ttl`

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,json,md,css,scss}\" package.json \"cypress/**/*.{ts,tsx,json,md,css,scss}\" \"**/*.{yml,yaml,md,json,html}\"",
     "build:ldo": "ldo build --input src/shapes --output src/ldo",
     "postbuild:ldo": "yarn format",
-    "cy:dev": "concurrently --kill-others \"BROWSER=none REACT_APP_COMMUNITY=http://localhost:4000/test-community/community#us REACT_APP_EMAIL_NOTIFICATIONS_SERVICE=http://localhost:3005 REACT_APP_EMAIL_NOTIFICATIONS_IDENTITY=https://example.com/bot/profile/card#me yarn start\" \"community-solid-server -p 4000 -l error\" \"CYPRESS_COMMUNITY=\\\"http://localhost:4000/test-community/community#us\\\" cypress open\""
+    "cy:dev": "concurrently --kill-others \"BROWSER=none REACT_APP_COMMUNITY=http://localhost:4000/test-community/community#us REACT_APP_EMAIL_NOTIFICATIONS_SERVICE=http://localhost:3005 REACT_APP_EMAIL_NOTIFICATIONS_IDENTITY=https://example.com/bot/profile/card#me yarn start\" \"community-solid-server -p 4000 -l error\" \"CYPRESS_COMMUNITY=\\\"http://localhost:4000/test-community/community#us\\\" CYPRESS_OTHER_COMMUNITY=\\\"http://localhost:4000/other-community/community#us\\\" cypress open\""
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
We make sure that only relevant hospex document is used in initial setup check.
Relevant hospex document contains triple `<person> <sioc:memberOf> <this community> .`
Before, data of multiple communities were conflicting with each other.

Fixes #48