### PR TITLE
Set up static ClientID at clientid.jsonld

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,7 @@ jobs:
           REACT_APP_COMMUNITY_CONTAINER: ${{ vars.COMMUNITY_CONTAINER }}
           REACT_APP_EMAIL_NOTIFICATIONS_SERVICE: ${{ vars.EMAIL_NOTIFICATIONS_SERVICE }}
           REACT_APP_EMAIL_NOTIFICATIONS_IDENTITY: ${{ vars.EMAIL_NOTIFICATIONS_IDENTITY }}
+          BASE_URL: ${{ vars.BASE_URL }} # base url for clientid.jsonld
 
       - name: Upload production-ready build files
         uses: actions/upload-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
           REACT_APP_COMMUNITY: http://localhost:4000/test-community/community#us'
           REACT_APP_EMAIL_NOTIFICATIONS_SERVICE: http://localhost:3005
           REACT_APP_EMAIL_NOTIFICATIONS_IDENTITY: https://example.com/bot/profile/card#me
+          REACT_APP_ENABLE_DEV_CLIENT_ID: true
           BROWSER: none
         with:
           start: yarn start, yarn community-solid-server -p 4000 -l error

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v5
         env:
+          NODE_ENV: test
           CYPRESS_COMMUNITY: http://localhost:4000/test-community/community#us'
           CYPRESS_OTHER_COMMUNITY: http://localhost:4000/other-community/community#us'
           CYPRESS_cssUrl: http://localhost:4000

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,6 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v5
         env:
-          NODE_ENV: test
           CYPRESS_COMMUNITY: http://localhost:4000/test-community/community#us'
           CYPRESS_OTHER_COMMUNITY: http://localhost:4000/other-community/community#us'
           CYPRESS_cssUrl: http://localhost:4000

--- a/cypress/e2e/login.cy.ts
+++ b/cypress/e2e/login.cy.ts
@@ -38,4 +38,20 @@ describe('Sign in to the app', () => {
     })
     cy.contains('We would like to set up your Pod')
   })
+
+  it('should use provided ClientID for sign-in', () => {
+    cy.visit('/')
+    cy.contains('Sign in').click()
+    cy.get<UserConfig>('@user1').then(user1 => {
+      cy.get('input[name=webIdOrIssuer]').type(`${user1.idp}{enter}`)
+      cy.origin(user1.idp, { args: { user1 } }, ({ user1 }) => {
+        cy.get('input[name=email]').type(user1.email)
+        cy.get('input[name=password]').type(`${user1.password}{enter}`)
+        // check that clientid.jsonld is used as ID
+        cy.contains('clientid.jsonld')
+        cy.get('button#authorize').click()
+      })
+    })
+    cy.contains('We would like to set up your Pod')
+  })
 })

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -9,6 +9,8 @@ You'll find [configurable options](#options) for the application here. We use en
 - `REACT_APP_EMAIL_NOTIFICATIONS_SERVICE` - server providing email notifications service along the lines of [solid-email-notifications](https://github.com/openHospitalityNetwork/solid-email-notifications); provide base url without trailing slash; notifications will be disabled if left empty
 - `REACT_APP_EMAIL_NOTIFICATIONS_IDENTITY` - identity of the email notifications service; app will allow this identity to read person's inbox
 - [default CreateReactApp options](https://create-react-app.dev/docs/advanced-configuration)
+- `BASE_URL` - this is base url for ClientID in ./public/clientid.jsonld, it's disabled in development environment by default (dynamic clientID is used), defaults to http://localhost:3000 in development, and https://sleepy.bike for build
+- `REACT_APP_ENABLE_DEV_CLIENT_ID` - enable static ClientID in development environment (see also `BASE_URL` option). If you set this option, you'll only be able to sign in with Solid Pod running on localhost! (dynamic clientID will be used by default)
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "react-scripts build && node scripts/build-clientid.js",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "preanalyze": "yarn build",
@@ -59,7 +59,7 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,json,md,css,scss}\" package.json \"cypress/**/*.{ts,tsx,json,md,css,scss}\" \"**/*.{yml,yaml,md,json,html}\"",
     "build:ldo": "ldo build --input src/shapes --output src/ldo",
     "postbuild:ldo": "yarn format",
-    "cy:dev": "concurrently --kill-others \"BROWSER=none REACT_APP_COMMUNITY=http://localhost:4000/test-community/community#us REACT_APP_EMAIL_NOTIFICATIONS_SERVICE=http://localhost:3005 REACT_APP_EMAIL_NOTIFICATIONS_IDENTITY=https://example.com/bot/profile/card#me yarn start\" \"community-solid-server -p 4000 -l error\" \"CYPRESS_COMMUNITY=\\\"http://localhost:4000/test-community/community#us\\\" CYPRESS_OTHER_COMMUNITY=\\\"http://localhost:4000/other-community/community#us\\\" cypress open\""
+    "cy:dev": "concurrently --kill-others \"BROWSER=none REACT_APP_COMMUNITY=http://localhost:4000/test-community/community#us REACT_APP_EMAIL_NOTIFICATIONS_SERVICE=http://localhost:3005 REACT_APP_ENABLE_DEV_CLIENT_ID=true REACT_APP_EMAIL_NOTIFICATIONS_IDENTITY=https://example.com/bot/profile/card#me yarn start\" \"community-solid-server -p 4000 -l error\" \"CYPRESS_COMMUNITY=\\\"http://localhost:4000/test-community/community#us\\\" CYPRESS_OTHER_COMMUNITY=\\\"http://localhost:4000/other-community/community#us\\\" cypress open\""
   },
   "browserslist": {
     "production": [

--- a/public/clientid.jsonld
+++ b/public/clientid.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": "https://www.w3.org/ns/solid/oidc-context.jsonld",
+  "client_id": "%BASE_URL%/clientid.jsonld",
+  "client_name": "sleepy.bike",
+  "redirect_uris": [
+    "%BASE_URL%/"
+  ],
+  "client_uri": "%BASE_URL%/",
+  "logo_uri": "%BASE_URL%/logo.svg",
+  "scope": "openid profile offline_access webid",
+  "grant_types": [
+    "refresh_token",
+    "authorization_code"
+  ],
+  "response_types": [
+    "code"
+  ]
+}

--- a/scripts/build-clientid.js
+++ b/scripts/build-clientid.js
@@ -1,0 +1,26 @@
+const fs = require('fs')
+const clientIdPath = './build/clientid.jsonld'
+
+/**
+ * Build script copies public/clientid.jsonld template to build/clientid.jsonld
+ * and in this script, we replace the %BASE_URL% in that file with relevant environment variable
+ * BASE_URL or 'https://' + VERCEL_BRANCH_URL or default 'https://sleepy.bike'
+ */
+
+// Read the template file
+let content = fs.readFileSync(clientIdPath, 'utf8')
+
+// Replace placeholders with actual values
+content = content.replaceAll(
+  '%BASE_URL%',
+  process.env.BASE_URL || // take environment variable
+    (process.env.VERCEL_BRANCH_URL &&
+      'https://' + process.env.VERCEL_BRANCH_URL) || // or vercel variable
+    'https://sleepy.bike', // or a default
+)
+
+// Write the content to the output file
+fs.writeFileSync(clientIdPath, content, 'utf8')
+
+// eslint-disable-next-line no-console
+console.log('ClientID generated successfully.')

--- a/src/components/SignIn/SignIn.tsx
+++ b/src/components/SignIn/SignIn.tsx
@@ -33,8 +33,13 @@ export const SignIn = () => {
     try {
       await login({
         oidcIssuer,
-        redirectUrl: window.location.href,
+        redirectUrl: new URL('/', window.location.href).toString(),
         clientName: 'sleepy.bike',
+        clientId:
+          process.env.NODE_ENV === 'development' &&
+          !process.env.REACT_APP_ENABLE_DEV_CLIENT_ID
+            ? undefined
+            : new URL('/clientid.jsonld', window.location.href).toJSON(),
       })
     } catch (e) {
       if (e instanceof TypeError) {

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,0 +1,23 @@
+const { readFileSync } = require('fs')
+
+/**
+ * Serve application clientId with correct urls in development environment
+ *
+ * You can specify the urls in BASE_URL environment variable
+ * It also takes BASE_URL of Vercel automatically (not sure if this is useful)
+ * By default BASE_URL is set to http://localhost:3000
+ */
+module.exports = function (app) {
+  app.get('/clientid.jsonld', (req, res) => {
+    const clientIdTemplate = readFileSync('./public/clientid.jsonld', 'utf8')
+    const clientId = clientIdTemplate.replaceAll(
+      '%BASE_URL%',
+      process.env.BASE_URL ??
+        (process.env.VERCEL_BRANCH_URL &&
+          'https://' + process.env.VERCEL_BRANCH_URL) ??
+        `http://localhost:${process.env.PORT ?? 3000}`,
+    )
+
+    res.end(clientId)
+  })
+}


### PR DESCRIPTION
This is useful mainly because the user will (hopefully) not have to click `Authorize` during sign-in every time.

Sign-in with Community Solid Server
![image](https://github.com/OpenHospitalityNetwork/sleepy.bike/assets/7449720/b27f9f8b-c223-409b-a061-b1892e32cea5)


Creates new environment variables:
`BASE_URL` - the app url without trailing slash that is used in ClientID
`REACT_APP_ENABLE_DEV_CLIENT_ID` - enable static ClientID in development

It's causing issues with Vercel previews. If you want to try and want it to work, you need to use "branch url", https://sleepy-bike-git-static-clientid-ohn.vercel.app/ in this case. If it's going to cause issues, we can disable this feature in Vercel altogether.