### PR TITLE
Notify matrix when a PR is ready for review.

### DIFF
--- a/.github/workflows/notify-on-pull-requests.yml
+++ b/.github/workflows/notify-on-pull-requests.yml
@@ -4,7 +4,7 @@ name: Notify matrix room when a pull request is opened (or reopened) or merged (
 
 on:
   pull_request:
-    types: [opened, reopened, closed]
+    types: [opened, reopened, ready_for_review, closed]
 
 jobs:
   ping_matrix_when_opened:


### PR DESCRIPTION
When a draft PR changes state to "ready for review", a message is sent to matrix room.