### PR TITLE
Change recommended pod to solidcommunity.net

### DIFF
--- a/src/components/Join/Join.tsx
+++ b/src/components/Join/Join.tsx
@@ -36,22 +36,22 @@ const tabs = [
       <>
         <ExternalButtonLink
           secondary
-          href="https://solidweb.me/idp/register/"
+          href="https://solidcommunity.net/register"
           target="_blank"
           rel="noopener noreferrer"
         >
-          Get a Pod at solidweb.me 😉
+          Get a Pod at solidcommunity.net 😉
         </ExternalButtonLink>
         <br />
-        It runs the{' '}
+        It is managed by the Solid community folks, and will be migrated to a{' '}
         <a
-          href="https://github.com/CommunitySolidServer/CommunitySolidServer"
+          href="https://github.com/solid-contrib/pivot"
           target="_blank"
           rel="noopener noreferrer"
         >
-          Community Solid Server
+          modern and open-source Solid server
         </a>
-        , which is modern and open-source.
+        .
       </>
     ),
   },

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -33,14 +33,14 @@ export const wikidataLDF = 'https://query.wikidata.org/bigdata/ldf'
 
 export const oidcIssuers = [
   {
-    issuer: 'https://solidweb.me',
-    registration: 'https://solidweb.me/idp/register/',
-    server: 'CSS',
-  },
-  {
     issuer: 'https://solidcommunity.net',
     registration: 'https://solidcommunity.net/register',
     server: 'NSS',
+  },
+  {
+    issuer: 'https://solidweb.me',
+    registration: 'https://solidweb.me/idp/register/',
+    server: 'CSS',
   },
   {
     issuer: 'https://solid.redpencil.io/',
@@ -49,7 +49,7 @@ export const oidcIssuers = [
   },
   {
     issuer: 'https://teamid.live/',
-    registration: 'https://teamid.live/idp/register/',
+    registration: 'https://teamid.live/.account/login/password/register/',
     server: 'CSS',
   },
   {


### PR DESCRIPTION
[Solidcommunity.net](https://solidcommunity.net) pod is managed by the Solid community folks, and will be migrated to a fork of [CSS](https://github.com/solid-contrib/pivot).

The currently recommended [solidweb.me](https://solidweb.me) is managed by a single person, and is therefore less reliable and future-proof.

Also, update a registration link for teamid.live.