### PR TITLE
Integrate simple email notifications

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,5 +22,5 @@ jobs:
           REACT_APP_ENABLE_DEV_CLIENT_ID: true
           BROWSER: none
         with:
-          start: yarn start, yarn community-solid-server -p 4000 -l error
-          wait-on: 'http://localhost:3000, http://localhost:4000'
+          start: yarn cy:github:app:notifications:simple, yarn cy:github:app:notifications:solid, yarn community-solid-server -p 4000 -l error
+          wait-on: 'http://localhost:3000, http://localhost:3001, http://localhost:4000'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,5 +22,8 @@ jobs:
           REACT_APP_ENABLE_DEV_CLIENT_ID: true
           BROWSER: none
         with:
+          # we run two apps - with solid- and simple-email-notifications enabled
+          # the app-specific environment variables are provided in package.json
+          # didn't find way to provide them to yarn start directly here
           start: yarn cy:github:app:notifications:simple, yarn cy:github:app:notifications:solid, yarn community-solid-server -p 4000 -l error
           wait-on: 'http://localhost:3000, http://localhost:3001, http://localhost:4000'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,6 @@
     "source.organizeImports": "explicit"
   },
   "yaml.schemas": {
-    "https://json.schemastore.org/github-workflow.json": "file:///home/michal/dev/ohn/sleepy.bike/sleepy.bike/.github/workflows/deploy.yml"
+    "https://json.schemastore.org/github-workflow.json": "file://.github/workflows/deploy.yml"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,9 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.organizeImports": true
+    "source.organizeImports": "explicit"
+  },
+  "yaml.schemas": {
+    "https://json.schemastore.org/github-workflow.json": "file:///home/michal/dev/ohn/sleepy.bike/sleepy.bike/.github/workflows/deploy.yml"
   }
 }

--- a/cypress/e2e/setup.cy.ts
+++ b/cypress/e2e/setup.cy.ts
@@ -96,6 +96,7 @@ describe('Setup Solid pod', () => {
     () => {
       beforeEach(setupPod())
 
+      // switch to the app on port 3001 which has the solid-email-notifications enabled
       before(() => {
         Cypress.config('baseUrl', 'http://localhost:3001')
       })

--- a/cypress/support/setup.ts
+++ b/cypress/support/setup.ts
@@ -450,6 +450,7 @@ export const stubMailer = ({
   integrated?: boolean
   verified?: boolean
 }): void => {
+  // interception for Solid mailer
   cy.intercept('GET', `${mailer}/status`, {
     statusCode: 200,
     body: {
@@ -459,4 +460,11 @@ export const stubMailer = ({
         : [],
     },
   })
+
+  // interception for simple mailer
+  cy.intercept(
+    'GET',
+    `http://localhost:3005/status/${encodeURIComponent(person.webId)}`,
+    { statusCode: 200, body: { emailVerified: integrated && verified } },
+  )
 }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,14 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,json,md,css,scss}\" package.json \"cypress/**/*.{ts,tsx,json,md,css,scss}\" \"**/*.{yml,yaml,md,json,html}\"",
     "build:ldo": "ldo build --input src/shapes --output src/ldo",
     "postbuild:ldo": "yarn format",
-    "cy:dev": "concurrently --kill-others \"BROWSER=none REACT_APP_COMMUNITY=http://localhost:4000/test-community/community#us REACT_APP_EMAIL_NOTIFICATIONS_SERVICE=http://localhost:3005 REACT_APP_ENABLE_DEV_CLIENT_ID=true REACT_APP_EMAIL_NOTIFICATIONS_IDENTITY=https://example.com/bot/profile/card#me yarn start\" \"community-solid-server -p 4000 -l error\" \"CYPRESS_COMMUNITY=\\\"http://localhost:4000/test-community/community#us\\\" CYPRESS_OTHER_COMMUNITY=\\\"http://localhost:4000/other-community/community#us\\\" cypress open\""
+    "cy:dev": "concurrently --kill-others \"yarn cy:dev:app:notifications:solid\" \"yarn cy:dev:app:notifications:simple\" \"yarn cy:dev:css\" \"yarn cy:dev:open\"",
+    "cy:dev:app": "BROWSER=none REACT_APP_COMMUNITY=http://localhost:4000/test-community/community#us REACT_APP_EMAIL_NOTIFICATIONS_SERVICE=http://localhost:3005 REACT_APP_ENABLE_DEV_CLIENT_ID=true REACT_APP_EMAIL_NOTIFICATIONS_IDENTITY=https://example.com/bot/profile/card#me yarn start",
+    "cy:dev:app:notifications:solid": "REACT_APP_EMAIL_NOTIFICATIONS_TYPE=solid PORT=3001 yarn cy:dev:app",
+    "cy:dev:app:notifications:simple": "REACT_APP_EMAIL_NOTIFICATIONS_TYPE=simple yarn cy:dev:app",
+    "cy:dev:css": "community-solid-server -p 4000 -l error",
+    "cy:dev:open": "CYPRESS_COMMUNITY=\"http://localhost:4000/test-community/community#us\" CYPRESS_OTHER_COMMUNITY=\"http://localhost:4000/other-community/community#us\" cypress open",
+    "cy:github:app:notifications:simple": "REACT_APP_EMAIL_NOTIFICATIONS_TYPE=simple yarn start",
+    "cy:github:app:notifications:solid": "REACT_APP_EMAIL_NOTIFICATIONS_TYPE=solid PORT=3001 yarn start"
   },
   "browserslist": {
     "production": [

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -23,6 +23,11 @@ export const emailNotificationsService =
 // TODO maybe we'll fetch the identity directly from the mailer, when it supports that option, so the setup will be less complicated
 export const emailNotificationsIdentity =
   process.env.REACT_APP_EMAIL_NOTIFICATIONS_IDENTITY ?? ''
+export const emailNotificationsType: 'simple' | 'solid' =
+  (process.env.REACT_APP_EMAIL_NOTIFICATIONS_TYPE as
+    | 'simple'
+    | 'solid'
+    | undefined) ?? 'simple'
 
 if (emailNotificationsService && !emailNotificationsIdentity)
   throw new Error(

--- a/src/hooks/data/useSetupHospex.ts
+++ b/src/hooks/data/useSetupHospex.ts
@@ -489,7 +489,7 @@ const useInitSimpleEmailNotifications = () => {
       email: string
       hospexDocument: string
     }) => {
-      // TODO give mailer read or write access to email settings, as needed
+      // give mailer read and write access to email settings, as needed
       await preparePodForSimpleEmailNotifications({
         hospexDocument,
         webId,
@@ -502,6 +502,8 @@ const useInitSimpleEmailNotifications = () => {
   )
 }
 
+// TODO this method runs very carelessly
+// in particular, we don't want to overwrite existing resources or data
 const usePreparePodForSimpleEmailNotifications = () => {
   const updateAclMutation = useUpdateLdoDocument(AuthorizationShapeType)
   const updateMutation = useUpdateRdfDocument()
@@ -554,7 +556,12 @@ const usePreparePodForSimpleEmailNotifications = () => {
           ldo.agent = [{ '@id': emailNotificationsIdentity }]
           ldo.accessTo = [{ '@id': emailSettings }]
           ldo.mode = [{ '@id': acl.Read }, { '@id': acl.Write }]
-
+        },
+      })
+      await updateAclMutation.mutateAsync({
+        uri: emailSettingsAcl,
+        subject: emailSettingsAcl + '#owner',
+        transform: ldo => {
           ldo['@id'] = emailSettingsAcl + '#owner'
           ldo.type = { '@id': 'Authorization' }
           ldo.agent = [{ '@id': webId }]

--- a/src/pages/HospexSetup.tsx
+++ b/src/pages/HospexSetup.tsx
@@ -20,10 +20,14 @@ export const HospexSetup = ({
   isHospexProfile,
   isInbox,
   isEmailNotifications,
+  isSimpleEmailNotifications,
   personalHospexDocuments,
   publicTypeIndexes,
   privateTypeIndexes,
   inboxes,
+  isNotificationsInitialized,
+  onNotificationsInitialized,
+  onNotificationsInitializedTryAgain,
 }: {
   isMember: boolean
   isHospexProfile: boolean
@@ -31,10 +35,14 @@ export const HospexSetup = ({
   isPrivateTypeIndex: boolean
   isInbox: boolean
   isEmailNotifications: boolean | 'unverified'
+  isSimpleEmailNotifications: boolean | 'unverified'
   personalHospexDocuments: URI[]
   publicTypeIndexes: URI[]
   privateTypeIndexes: URI[]
   inboxes: URI[]
+  isNotificationsInitialized: boolean
+  onNotificationsInitialized: () => void
+  onNotificationsInitializedTryAgain: () => void
 }) => {
   const auth = useAuth()
   const setupHospex = useSetupHospex()
@@ -50,7 +58,8 @@ export const HospexSetup = ({
       !isPrivateTypeIndex ||
       !isHospexProfile ||
       !isInbox ||
-      !isEmailNotifications
+      !isEmailNotifications ||
+      !isSimpleEmailNotifications
     ) {
       const tasks: SetupTask[] = []
       if (!isPublicTypeIndex) tasks.push('createPublicTypeIndex')
@@ -58,6 +67,8 @@ export const HospexSetup = ({
       if (!isHospexProfile) tasks.push('createHospexProfile')
       if (!isInbox) tasks.push('createInbox')
       if (!isEmailNotifications) tasks.push('integrateEmailNotifications')
+      if (!isSimpleEmailNotifications)
+        tasks.push('integrateSimpleEmailNotifications')
       if (!auth.webId) throw new Error('not signed in')
       if (isPublicTypeIndex && !publicTypeIndexes[0])
         throw new Error('existing public type index not found')
@@ -78,6 +89,7 @@ export const HospexSetup = ({
         email,
       }
       await setupHospex(tasks, settings)
+      onNotificationsInitialized()
     }
     if (!isMember)
       await joinGroup({
@@ -130,6 +142,27 @@ export const HospexSetup = ({
           {isEmailNotifications === 'unverified' && (
             <div>Please verify your email</div>
           )}
+        </li>
+        <li>
+          {!isSimpleEmailNotifications &&
+            (!isNotificationsInitialized ? (
+              <div>
+                Setup simple email notifications{' '}
+                <input
+                  type="email"
+                  placeholder="Your email"
+                  value={email}
+                  onChange={e => setEmail(e.target.value)}
+                />
+              </div>
+            ) : (
+              <div>
+                Please verify your email. Email didn't arrive?{' '}
+                <Button secondary onClick={onNotificationsInitializedTryAgain}>
+                  Try again
+                </Button>
+              </div>
+            ))}
         </li>
       </ul>
       <Button primary onClick={() => handleClickSetup()}>

--- a/src/pages/SetupOutlet.tsx
+++ b/src/pages/SetupOutlet.tsx
@@ -1,18 +1,26 @@
 import { useAppSelector } from 'app/hooks'
 import { Loading } from 'components'
-import { communityId, emailNotificationsService } from 'config'
+import {
+  communityId,
+  emailNotificationsService,
+  emailNotificationsType,
+} from 'config'
 import { selectAuth } from 'features/auth/authSlice'
 import {
   useCheckEmailNotifications,
   useCheckSetup,
+  useCheckSimpleEmailNotifications,
 } from 'hooks/data/useCheckSetup'
 import { omit } from 'lodash'
+import { useState } from 'react'
 import { Outlet } from 'react-router-dom'
 import { NonUndefined } from 'utility-types'
 import { HospexSetup } from './HospexSetup'
 
 export const SetupOutlet = () => {
   const auth = useAppSelector(selectAuth)
+  const [notificationsInitialized, setNotificationsInitialized] =
+    useState(false)
 
   const setupCheck = useCheckSetup(auth.webId ?? '', communityId ?? '')
   const tasks = omit(setupCheck, [
@@ -22,24 +30,34 @@ export const SetupOutlet = () => {
   ])
 
   // set up email
+  const isSimpleEmailNotifications = useCheckSimpleEmailNotifications(
+    auth.webId as string,
+    emailNotificationsType === 'simple' ? emailNotificationsService : '',
+  )
   const isEmailNotifications = useCheckEmailNotifications(
     setupCheck.inboxes[0],
-    emailNotificationsService,
+    emailNotificationsType === 'solid' ? emailNotificationsService : '',
   )
 
   const isEverythingSetUp =
-    Object.values(setupCheck).every(v => v) && isEmailNotifications === true
+    Object.values(setupCheck).every(v => v) &&
+    isSimpleEmailNotifications === true &&
+    isEmailNotifications === true
 
   if (isEverythingSetUp) return <Outlet />
 
   const checks = Object.entries(tasks)
     .filter(([, value]) => value === undefined)
     .map(([key]) => key)
+  if (isSimpleEmailNotifications === undefined) {
+    checks.push('isSimpleEmailNotifications')
+  }
   if (isEmailNotifications === undefined) {
     checks.push('isEmailNotifications')
   }
   if (
     Object.values(setupCheck).some(a => a === undefined) ||
+    isSimpleEmailNotifications === undefined ||
     isEmailNotifications === undefined
   )
     return <Loading>Checking {checks.join(', ')}</Loading>
@@ -47,7 +65,13 @@ export const SetupOutlet = () => {
   return (
     <HospexSetup
       {...(setupCheck as DefinedProps<typeof setupCheck>)}
+      isSimpleEmailNotifications={isSimpleEmailNotifications}
       isEmailNotifications={isEmailNotifications}
+      onNotificationsInitialized={() => setNotificationsInitialized(true)}
+      onNotificationsInitializedTryAgain={() =>
+        setNotificationsInitialized(false)
+      }
+      isNotificationsInitialized={notificationsInitialized}
     />
   )
 }


### PR DESCRIPTION
Implement the integration of [simple mail notifications](
https://github.com/openHospitalityNetwork/simple-email-notifications) into sleepy.bike
- initialize email verification via `POST /init` at the beginning
- prepare pod for the email service - the service needs to be able to find, read and write email verification token in the pod

Also write related tests. In particular run the app twice - with solid- and with simple-email-notifications, to test both options.

TODO in next PRs:
- send email notification when person sends a message or a contact request.

Partially fixes #71