### PR TITLE
Disable Vercel build of gh-pages branch

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "git": {
+    "deploymentEnabled": {
+      "gh-pages": false
+    }
+  }
+}


### PR DESCRIPTION
The gh-pages branch already contains a build,
so Vercel fails trying to build it.

So we disable the build in vercel.json
https://vercel.com/docs/projects/project-configuration/git-configuration#git.deploymentenabled