### PR TITLE
Fix user profile overwriting issue

### DIFF
--- a/src/hooks/data/useRdfDocument.ts
+++ b/src/hooks/data/useRdfDocument.ts
@@ -159,7 +159,7 @@ export const useCreateRdfDocument = <S extends LdoBase>(
         body: turtleData,
         headers: {
           'content-type': 'text/turtle',
-          'If-None-Match': '*'
+          'If-None-Match': '*',
         },
       })
 

--- a/src/hooks/data/useRdfDocument.ts
+++ b/src/hooks/data/useRdfDocument.ts
@@ -159,7 +159,7 @@ export const useCreateRdfDocument = <S extends LdoBase>(
         body: turtleData,
         headers: {
           'content-type': 'text/turtle',
-          // 'If-None-Match': '*'
+          'If-None-Match': '*'
         },
       })
 

--- a/src/hooks/data/useRdfDocument.ts
+++ b/src/hooks/data/useRdfDocument.ts
@@ -150,18 +150,16 @@ export const useCreateRdfDocument = <S extends LdoBase>(
         setLanguagePreferences(language).using(ldo)
         merge(ldo, data)
       }
-      const turtleData = await toTurtle(
+      const body = await toTurtle(
         ldoDataset.usingType(shapeType).fromSubject(''),
       )
 
-      const response = await fullFetch(uri, {
-        method,
-        body: turtleData,
-        headers: {
-          'content-type': 'text/turtle',
-          'If-None-Match': '*',
-        },
-      })
+      const headers: HeadersInit = { 'content-type': 'text/turtle' }
+      // let's make sure we don't overwrite an existing resource
+      // https://solidproject.org/TR/protocol#conditional-update
+      if (method === 'PUT') headers['If-None-Match'] = '*'
+
+      const response = await fullFetch(uri, { method, body, headers })
 
       const location = response.headers.get('location')
       return location as string


### PR DESCRIPTION
After Solid specification:
> NOTE: Conditional Update
>
> Clients are encouraged to use the HTTP If-None-Match header with a value of "*" to prevent an unsafe request method, e.g., PUT, PATCH, from inadvertently modifying an existing representation of the target resource when the client believes that the resource does not have a current representation. 

(source: https://solidproject.org/TR/protocol#conditional-update)
