### PR TITLE
Remove solidweb.me from recommended pod providers

### DIFF
--- a/src/components/Join/Join.tsx
+++ b/src/components/Join/Join.tsx
@@ -13,18 +13,20 @@ const tabs = [
       <>
         Here are some Pod providers that work with sleepy.bike:
         <ul>
-          {oidcIssuers.map(({ issuer, registration }) => (
-            <li>
-              <ExternalButtonLink
-                secondary
-                href={registration}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {new URL(issuer).hostname}
-              </ExternalButtonLink>
-            </li>
-          ))}
+          {oidcIssuers
+            .filter(iss => iss.registration)
+            .map(({ issuer, registration }) => (
+              <li key={issuer}>
+                <ExternalButtonLink
+                  secondary
+                  href={registration}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {new URL(issuer).hostname}
+                </ExternalButtonLink>
+              </li>
+            ))}
         </ul>
       </>
     ),
@@ -104,9 +106,11 @@ const tabs = [
         </p>
         <ul>
           {oidcIssuers
-            .filter(({ server }) => server === 'CSS')
+            .filter(
+              ({ server, registration }) => registration && server === 'CSS',
+            )
             .map(({ issuer, registration }) => (
-              <li>
+              <li key={issuer}>
                 <ExternalButtonLink
                   secondary
                   href={registration}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -36,7 +36,11 @@ if (emailNotificationsService && !emailNotificationsIdentity)
 
 export const wikidataLDF = 'https://query.wikidata.org/bigdata/ldf'
 
-export const oidcIssuers = [
+export const oidcIssuers: {
+  issuer: string
+  registration?: string
+  server: 'NSS' | 'CSS'
+}[] = [
   {
     issuer: 'https://solidcommunity.net',
     registration: 'https://solidcommunity.net/register',
@@ -44,7 +48,6 @@ export const oidcIssuers = [
   },
   {
     issuer: 'https://solidweb.me',
-    registration: 'https://solidweb.me/idp/register/',
     server: 'CSS',
   },
   {


### PR DESCRIPTION
Solidweb.me has been deprecated and is probably going to reach end of life at the end of 2024, see #91

We remove solidweb.me from the _Join_ list, but keep it in _Sign in_ list. We want people to be able to keep using it, but not register new accounts with it.

Also fix a warning regarding missing keys in list.