### PR TITLE
Remove bottom navigation from home, host and travel pages

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -38,6 +38,7 @@ svg {
   display: initial;
 }
 
+@import 'styles/generic';
 @import 'styles/form';
 @import 'styles/menu';
 

--- a/src/layouts/NavLayout.module.scss
+++ b/src/layouts/NavLayout.module.scss
@@ -1,8 +1,11 @@
 .container {
-  height: calc(100% - 4rem);
-  margin-bottom: 4rem;
+  height: 100%; //calc(100% - 4rem);
+  // margin-bottom: 4rem;
 }
 
+//// disabled the bottom navigation in NavLayout
+//// until we have use for the other tabs, or decide to remove this
+/*
 .navigation {
   position: fixed;
   bottom: 0;
@@ -30,3 +33,4 @@
     }
   }
 }
+*/

--- a/src/pages/Home.module.scss
+++ b/src/pages/Home.module.scss
@@ -2,19 +2,15 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
+  align-items: center;
   height: 100%;
-  gap: 1rem;
-  // padding-bottom: 2rem;
+  gap: 1.2rem;
 
-  .specialLink {
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    border: 2px solid black;
-    height: 4rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  // customize style of buttons on home
+  a {
+    padding: 1rem;
+    max-width: 20rem;
+    width: 100%;
+    gap: 0.8rem;
   }
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,9 +1,7 @@
 import { ButtonLink } from 'components'
 import { useReadMessagesFromInbox } from 'hooks/data/useReadThreads'
 import { useAuth } from 'hooks/useAuth'
-import { NavLayout } from 'layouts/NavLayout'
-import { useMemo } from 'react'
-import { FaRegComment } from 'react-icons/fa'
+import { FaDoorOpen, FaMap, FaRegComment } from 'react-icons/fa'
 import styles from './Home.module.scss'
 
 export const Home = () => {
@@ -11,31 +9,18 @@ export const Home = () => {
 
   const { data: newMessages } = useReadMessagesFromInbox(auth.webId!)
 
-  const tabs = useMemo(
-    () => [
-      {
-        link: 'messages',
-        label: (
-          <span>
-            <FaRegComment size={32} />
-            {newMessages?.length ? ` (${newMessages.length} new)` : null}
-          </span>
-        ),
-      },
-    ],
-    [newMessages],
-  )
-
   return (
-    <NavLayout tabs={tabs}>
-      <div className={styles.container}>
-        <ButtonLink to="travel" secondary>
-          travel
-        </ButtonLink>
-        <ButtonLink to="host" secondary>
-          host
-        </ButtonLink>
-      </div>
-    </NavLayout>
+    <div className={styles.container}>
+      <ButtonLink to="travel" secondary>
+        <FaMap size={24} /> travel
+      </ButtonLink>
+      <ButtonLink to="host" secondary>
+        <FaDoorOpen size={24} /> host
+      </ButtonLink>
+      <ButtonLink to="messages" secondary>
+        <FaRegComment size={24} /> messages
+        {newMessages?.length ? ` (${newMessages.length} new)` : null}
+      </ButtonLink>
+    </div>
   )
 }

--- a/src/pages/HostOutlet.tsx
+++ b/src/pages/HostOutlet.tsx
@@ -1,15 +1,15 @@
 import { NavLayout } from 'layouts/NavLayout'
 import { Outlet } from 'react-router-dom'
 
-const tabs = [
-  { link: 'offers', label: 'my offers' },
-  { link: 'invite', label: 'invite people' },
-  { link: 'guests', label: 'my guests' },
-]
+// const tabs = [
+//   { link: 'offers', label: 'my offers' },
+//   { link: 'invite', label: 'invite people' },
+//   { link: 'guests', label: 'my guests' },
+// ]
 
 export const HostOutlet = () => {
   return (
-    <NavLayout tabs={tabs}>
+    <NavLayout tabs={[]}>
       <Outlet />
     </NavLayout>
   )

--- a/src/pages/MyOffers.module.scss
+++ b/src/pages/MyOffers.module.scss
@@ -9,6 +9,13 @@
   gap: 2rem;
 
   padding-bottom: 2rem;
+
+  .header {
+    align-self: start;
+    * {
+      vertical-align: text-bottom;
+    }
+  }
 }
 
 .accommodation {

--- a/src/pages/MyOffers.tsx
+++ b/src/pages/MyOffers.tsx
@@ -9,6 +9,7 @@ import { useReadAccommodations } from 'hooks/data/useReadAccommodations'
 import { useUpdateAccommodation } from 'hooks/data/useUpdateAccommodation'
 import { useAuth } from 'hooks/useAuth'
 import { useState } from 'react'
+import { FaDoorOpen } from 'react-icons/fa'
 import { Accommodation, URI } from 'types'
 import { getContainer } from 'utils/helpers'
 import styles from './MyOffers.module.scss'
@@ -71,6 +72,9 @@ export const MyOffers = () => {
 
   return (
     <div className={styles.container}>
+      <h1 className={styles.header}>
+        <FaDoorOpen size={32} /> My Accommodation Offers
+      </h1>
       <ul style={{ display: 'contents' }}>
         {accommodations.map(accommodation =>
           editing === accommodation.id ? (
@@ -102,7 +106,6 @@ export const MyOffers = () => {
           ),
         )}
       </ul>
-      {/* <pre>{JSON.stringify(accommodations, null, 2)}</pre> */}
       {editing === 'new' ? (
         <AccommodationForm
           onSubmit={handleCreate}

--- a/src/pages/TravelOutlet.tsx
+++ b/src/pages/TravelOutlet.tsx
@@ -1,15 +1,15 @@
 import { NavLayout } from 'layouts/NavLayout'
 import { Outlet } from 'react-router-dom'
 
-const tabs = [
-  { link: 'search', label: 'search hosts' },
-  { link: 'plans', label: 'plans' },
-  { link: 'hosts', label: 'my hosts' },
-]
+// const tabs = [
+//   { link: 'search', label: 'search hosts' },
+//   { link: 'plans', label: 'plans' },
+//   { link: 'hosts', label: 'my hosts' },
+// ]
 
 export const TravelOutlet = () => {
   return (
-    <NavLayout tabs={tabs}>
+    <NavLayout tabs={[]}>
       <Outlet />
     </NavLayout>
   )

--- a/src/styles/generic.scss
+++ b/src/styles/generic.scss
@@ -1,0 +1,3 @@
+h1 {
+  font-size: 1.7rem;
+}


### PR DESCRIPTION
Removed the unnecessary and confusing bottom navigation buttons. Currently, they don't lead anywhere.

### Map

<img src="https://github.com/OpenHospitalityNetwork/sleepy.bike/assets/7449720/2f0ea29e-68ad-4b38-a5a0-64596fd2ad17" alt="map before" width="300"> :arrow_right: <img src="https://github.com/OpenHospitalityNetwork/sleepy.bike/assets/7449720/93db6f2b-1bb2-4719-a0e2-1b5729918998" alt="map after" width="300" />

### My Accommodation Offers

<img src="https://github.com/OpenHospitalityNetwork/sleepy.bike/assets/7449720/5cb72c47-4f17-49fb-ad5b-5e84fe78b5b1" alt="my offers before" width="300" />:arrow_right: <img src="https://github.com/OpenHospitalityNetwork/sleepy.bike/assets/7449720/73977ef1-e8e9-4640-bddc-8361bf244898" alt="my offers after" width="300" />

### Home

<img src="https://github.com/OpenHospitalityNetwork/sleepy.bike/assets/7449720/350350f1-4f6a-4637-b9fc-cd2cc476a0b4" alt="homepage before" width="300" /> :arrow_right: <img src="https://github.com/OpenHospitalityNetwork/sleepy.bike/assets/7449720/9fe5ef2d-2d18-46f9-9080-d555627ce4e1" width="300" alt="homepage after" />