### PR TITLE
Remember last selected identity provider

### DIFF
--- a/cypress/e2e/login.cy.ts
+++ b/cypress/e2e/login.cy.ts
@@ -54,4 +54,49 @@ describe('Sign in to the app', () => {
     })
     cy.contains('We would like to set up your Pod')
   })
+
+  it('should remember last identity provider selected during login', () => {
+    cy.visit('/')
+    cy.contains('Sign in').click()
+    cy.get('input[name=webIdOrIssuer]').should('have.value', '')
+    // the provider should also be the first highlighted button
+    cy.get<UserConfig>('@user1').then(user1 => {
+      // sign in using custom provider
+      cy.login(user1)
+      cy.contains('We would like to set up your Pod')
+      // sign out
+      cy.logout()
+
+      cy.visit('/')
+      cy.contains('Sign in').click()
+      // the custom provider should be filled in
+      cy.get('input[name=webIdOrIssuer]').should('have.value', user1.idp)
+      // the provider should also be the first highlighted button
+      cy.get('[class^=SignIn_providers] button')
+        .first()
+        .contains(user1.idp.slice(7, -1))
+    })
+  })
+
+  it('should remember last provider selected at signup', () => {
+    cy.visit('/')
+    cy.contains('Join').click()
+    cy.get('label').contains('Show me some providers!').click()
+    cy.get('[class^=Join_podOptions] a ')
+      .contains('solidcommunity.net')
+      // prevent opening new window (breaks CI tests)
+      .invoke('removeAttr', 'target')
+      .invoke('removeAttr', 'rel')
+      .invoke('removeAttr', 'href')
+      .click()
+
+    // close signup and open signin
+    cy.get('label').contains('Show me some providers!').type('{esc}')
+    cy.contains('Sign in').click()
+
+    // the provider should be the first highlighted button
+    cy.get('[class^=SignIn_providers] button')
+      .first()
+      .contains('solidcommunity.net')
+  })
 })

--- a/cypress/support/authentication.ts
+++ b/cypress/support/authentication.ts
@@ -3,7 +3,7 @@ import { UserConfig } from './css-authentication'
 export const uiLogin = (user: UserConfig) => {
   cy.visit('/')
   cy.contains('Sign in').click()
-  cy.get('input[name=webIdOrIssuer]').type(`${user.idp}{enter}`)
+  cy.get('input[name=webIdOrIssuer]').clear().type(`${user.idp}{enter}`)
   cy.origin(user.idp, { args: { user } }, ({ user }) => {
     cy.get('input[name=email]').type(user.email)
     cy.get('input[name=password]').type(`${user.password}{enter}`)

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -5,21 +5,42 @@ import {
   Reducer,
 } from '@reduxjs/toolkit'
 import * as authSlice from 'features/auth/authSlice'
+import * as loginSlice from 'features/login/loginSlice'
+import { persistReducer, persistStore } from 'redux-persist'
+import storage from 'redux-persist/lib/storage'
 
 const appReducer = combineReducers({
   auth: authSlice.reducer,
+  login: loginSlice.reducer,
 })
 
 // clear redux state when signing out
 const rootReducer: Reducer<RootState> = (state, action) => {
   if (isAnyOf(authSlice.actions.signout)(action)) {
-    return appReducer(undefined, action)
+    const emptyState = appReducer(undefined, action)
+
+    // clear state but remember last selected issuer for next login
+    const lastSelectedIssuer =
+      state && loginSlice.selectLastSelectedIssuer(state)
+    if (lastSelectedIssuer)
+      return appReducer(
+        emptyState,
+        loginSlice.actions.setLastSelectedIssuer(lastSelectedIssuer),
+      )
+
+    return emptyState
   }
 
   return appReducer(state, action)
 }
 
-export const store = configureStore({ reducer: rootReducer })
+// setup redux-persist with local storage
+// to keep some data across page refresh
+const persistConfig = { key: 'root', storage, whitelist: ['login'] }
+const persistedReducer = persistReducer(persistConfig, rootReducer)
+
+export const store = configureStore({ reducer: persistedReducer })
+export const persistor = persistStore(store)
 
 // Infer the `RootState` and `AppDispatch` types from the store
 export type RootState = ReturnType<typeof appReducer>

--- a/src/components/Join/Join.tsx
+++ b/src/components/Join/Join.tsx
@@ -1,9 +1,35 @@
+import { useAppDispatch } from 'app/hooks'
 import { Button } from 'components'
 import { ExternalButtonLink } from 'components/Button/Button'
-import { oidcIssuers } from 'config'
-import { ChangeEvent, Fragment, useState } from 'react'
+import { oidcIssuers, type IssuerConfig } from 'config'
+import { actions } from 'features/login/loginSlice'
+import { ChangeEvent, Fragment, ReactNode, useState } from 'react'
 import Modal from 'react-modal'
 import styles from './Join.module.scss'
+
+const RegistrationButton = ({
+  issuer,
+  registration,
+  children,
+}: Pick<IssuerConfig, 'issuer' | 'registration'> & {
+  children?: ReactNode
+}) => {
+  const dispatch = useAppDispatch()
+
+  return (
+    <ExternalButtonLink
+      secondary
+      href={registration!}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={() => {
+        dispatch(actions.setLastSelectedIssuer(issuer))
+      }}
+    >
+      {children ?? new URL(issuer).hostname}
+    </ExternalButtonLink>
+  )
+}
 
 const tabs = [
   {
@@ -15,16 +41,9 @@ const tabs = [
         <ul>
           {oidcIssuers
             .filter(iss => iss.registration)
-            .map(({ issuer, registration }) => (
-              <li key={issuer}>
-                <ExternalButtonLink
-                  secondary
-                  href={registration}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {new URL(issuer).hostname}
-                </ExternalButtonLink>
+            .map(issuerConfig => (
+              <li key={issuerConfig.issuer}>
+                <RegistrationButton {...issuerConfig} />
               </li>
             ))}
         </ul>
@@ -34,16 +53,12 @@ const tabs = [
   {
     id: 'choose-for-me',
     label: 'Choose for me!',
+    // TODO put this label and description into config
     content: (
       <>
-        <ExternalButtonLink
-          secondary
-          href="https://solidcommunity.net/register"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <RegistrationButton {...oidcIssuers.find(iss => iss.recommended)!}>
           Get a Pod at solidcommunity.net 😉
-        </ExternalButtonLink>
+        </RegistrationButton>
         <br />
         It is managed by the Solid community folks, and will be migrated to a{' '}
         <a
@@ -109,16 +124,9 @@ const tabs = [
             .filter(
               ({ server, registration }) => registration && server === 'CSS',
             )
-            .map(({ issuer, registration }) => (
-              <li key={issuer}>
-                <ExternalButtonLink
-                  secondary
-                  href={registration}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {new URL(issuer).hostname}
-                </ExternalButtonLink>
+            .map(issuerConfig => (
+              <li key={issuerConfig.issuer}>
+                <RegistrationButton {...issuerConfig} />
               </li>
             ))}
         </ul>

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -36,18 +36,25 @@ if (emailNotificationsService && !emailNotificationsIdentity)
 
 export const wikidataLDF = 'https://query.wikidata.org/bigdata/ldf'
 
-export const oidcIssuers: {
+export type IssuerConfig = {
+  recommended?: boolean // the recommended provider for sign up
+  featured?: boolean // featured providers for sign in
   issuer: string
   registration?: string
   server: 'NSS' | 'CSS'
-}[] = [
+}
+
+export const oidcIssuers: IssuerConfig[] = [
   {
+    recommended: true,
+    featured: true,
     issuer: 'https://solidcommunity.net',
     registration: 'https://solidcommunity.net/register',
     server: 'NSS',
   },
   {
-    issuer: 'https://solidweb.me',
+    featured: true,
+    issuer: 'https://solidweb.me/',
     server: 'CSS',
   },
   {

--- a/src/features/login/loginSlice.ts
+++ b/src/features/login/loginSlice.ts
@@ -1,0 +1,24 @@
+import type { PayloadAction } from '@reduxjs/toolkit'
+import { createSlice } from '@reduxjs/toolkit'
+import { RootState } from 'app/store'
+
+interface LoginState {
+  lastSelectedIssuer?: string
+}
+
+const initialState: LoginState = {}
+
+export const slice = createSlice({
+  name: 'login',
+  initialState,
+  reducers: {
+    setLastSelectedIssuer: (state, action: PayloadAction<string>) => {
+      state.lastSelectedIssuer = action.payload
+    },
+  },
+})
+
+export const { actions, reducer } = slice
+
+export const selectLastSelectedIssuer = (state: RootState) =>
+  state.login.lastSelectedIssuer

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,12 +1,13 @@
 import './index.scss'
 // this line intentionally left blank to load css reset stylesheets first
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { store } from 'app/store'
+import { persistor, store } from 'app/store'
 import 'config'
 import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { Provider } from 'react-redux'
 import { RouterProvider } from 'react-router-dom'
+import { PersistGate } from 'redux-persist/integration/react'
 import { router } from 'router'
 import { reportWebVitals } from './reportWebVitals'
 
@@ -18,9 +19,11 @@ const root = createRoot(document.getElementById('root') as HTMLElement)
 root.render(
   <React.StrictMode>
     <Provider store={store}>
-      <QueryClientProvider client={queryClient}>
-        <RouterProvider router={router} />
-      </QueryClientProvider>
+      <PersistGate loading={null} persistor={persistor}>
+        <QueryClientProvider client={queryClient}>
+          <RouterProvider router={router} />
+        </QueryClientProvider>
+      </PersistGate>
     </Provider>
   </React.StrictMode>,
 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -15399,7 +15399,7 @@ redis-parser@^3.0.0:
 
 redux-persist@^6.0.0:
   version "6.0.0"
-  resolved "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz"
+  resolved "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz#b4d2972f9859597c130d40d4b146fecdab51b3a8"
   integrity sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==
 
 redux-thunk@^2.4.2:


### PR DESCRIPTION
This should help people remember their Solid provider for login, and not have to type their custom provider every time.

Provider selected from offered options at Join, and selected from existing providers at SignIn gets remembered for later.

### Listed provider

![listed provider next time](https://github.com/OpenHospitalityNetwork/sleepy.bike/assets/7449720/c6989e09-45c4-4274-a566-55c053d44e5e)

### Custom provider

![custom provider next time](https://github.com/OpenHospitalityNetwork/sleepy.bike/assets/7449720/81cb4cb0-41a6-4d72-9ed5-b32bdeabaf60)