### PR TITLE
Fix image ratio in Avatar component

### DIFF
--- a/src/components/Avatar/Avatar.module.scss
+++ b/src/components/Avatar/Avatar.module.scss
@@ -3,6 +3,8 @@
   // width: 2rem;
   border-radius: 1000rem;
   display: inline-block;
+  object-fit: cover;
+
   &.square {
     border-radius: 0;
   }


### PR DESCRIPTION
When uploaded image isn't exactly square, Avatar should still have correct ratio.

Before:

![avatar distorted aspect ratio](https://github.com/OpenHospitalityNetwork/sleepy.bike/assets/7449720/118843c4-761a-4a91-9899-8f21fbd4538a)

After:

![avatar correct aspect ratio](https://github.com/OpenHospitalityNetwork/sleepy.bike/assets/7449720/372921ad-a246-441e-89c4-74a864d08d0d)

Original:

<a href="https://commons.wikimedia.org/wiki/File:Black-bellied_whistling_ducks_(Dendrocygna_autumnalis).jpg#/media/File:Black-bellied_whistling_ducks_(Dendrocygna_autumnalis).jpg"><img src="https://upload.wikimedia.org/wikipedia/commons/7/74/Black-bellied_whistling_ducks_%28Dendrocygna_autumnalis%29.jpg" alt="Dendrocygna autumnalis (Black-bellied Whistling Ducks)" height="260" width="640"></a>
