### PR TITLE
Stop moving map in my hosting offers

### DIFF
--- a/src/components/AccommodationView/AccommodationView.tsx
+++ b/src/components/AccommodationView/AccommodationView.tsx
@@ -32,6 +32,8 @@ export const AccommodationView = (accommodation: Accommodation) => {
         scrollWheelZoom="center"
         doubleClickZoom="center"
         touchZoom="center"
+        dragging={false}
+        keyboard={false}
       >
         <TileLayer url={tileServer} />
         <Marker position={location} />


### PR DESCRIPTION
Allow only zoom.

It's this map

![image](https://github.com/OpenHospitalityNetwork/sleepy.bike/assets/7449720/9b02b7c6-0e49-4960-9fee-3e397fceab2c)

and the goal is to keep it centered at the accommodation's location.