### PR TITLE
Redirect to previous URL after login

### DIFF
--- a/cypress/e2e/login.cy.ts
+++ b/cypress/e2e/login.cy.ts
@@ -1,3 +1,4 @@
+import { Person } from '../support/commands'
 import { UserConfig } from '../support/css-authentication'
 
 describe('Sign in to the app', () => {
@@ -98,5 +99,21 @@ describe('Sign in to the app', () => {
     cy.get('[class^=SignIn_providers] button')
       .first()
       .contains('solidcommunity.net')
+  })
+
+  it('should return to previous URL after login', () => {
+    cy.createPerson().as('person')
+    cy.visit('/profile/edit?a=b&c=d#ef')
+    cy.contains('Sign in').click()
+    cy.get<Person>('@person').then(person => {
+      cy.stubMailer({ person })
+      cy.get('input[name=webIdOrIssuer]').type(`${person.idp}{enter}`)
+      cy.origin(person.idp, { args: { person } }, ({ person }) => {
+        cy.get('input[name=email]').type(person.email)
+        cy.get('input[name=password]').type(`${person.password}{enter}`)
+        cy.get('button#authorize').click()
+      })
+    })
+    cy.url().should('include', '/profile/edit?a=b&c=d#ef')
   })
 })

--- a/src/hooks/usePreviousUriAfterLogin.ts
+++ b/src/hooks/usePreviousUriAfterLogin.ts
@@ -1,0 +1,30 @@
+import { useAppSelector } from 'app/hooks'
+import { selectAuth } from 'features/auth/authSlice'
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+export const usePreviousUriAfterLogin = () => {
+  const auth = useAppSelector(selectAuth)
+  const navigate = useNavigate()
+
+  // navigate to previous URI after login
+  useEffect(() => {
+    // save url to get back to it after login
+    if (auth.isLoggedIn === false) {
+      const currentUrl = globalThis.location.href
+      globalThis.localStorage.setItem('previousUrl', currentUrl)
+    }
+
+    // redirect to previous url
+    if (auth.isLoggedIn === true) {
+      const previousUrl = globalThis.localStorage.getItem('previousUrl')
+      if (previousUrl) {
+        const url = new URL(previousUrl)
+        // make sure domain matches, then navigate to previous url
+        if (url.hostname === new URL(globalThis.location.href).hostname)
+          navigate(url.pathname + url.search + url.hash, { replace: true })
+      }
+      globalThis.localStorage.removeItem('previousUrl')
+    }
+  }, [auth.isLoggedIn, navigate])
+}

--- a/src/pages/AuthenticatedOutlet.tsx
+++ b/src/pages/AuthenticatedOutlet.tsx
@@ -1,10 +1,13 @@
 import { useAppSelector } from 'app/hooks'
 import { Loading } from 'components/Loading/Loading'
 import { selectAuth } from 'features/auth/authSlice'
+import { usePreviousUriAfterLogin } from 'hooks/usePreviousUriAfterLogin'
 import { SetupOutlet } from './SetupOutlet'
 import { UnauthenticatedHome } from './UnauthenticatedHome'
 
 export const AuthenticatedOutlet = () => {
+  usePreviousUriAfterLogin()
+
   const auth = useAppSelector(selectAuth)
 
   if (auth.isLoggedIn === undefined) return <Loading>Authenticating...</Loading>


### PR DESCRIPTION
When user is signed out, we store the url in localStorage.
When user is signed in, we retrieve the url from localStorage and redirect to it.

Fixes #86