### PR TITLE
Allow user to select existing hospex folder when joining community

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -18,6 +18,7 @@ rules:
   'prettier/prettier': warn
   'no-console': warn
   'import/no-default-export': error
+  # TODO later import/no-cycle: warn
   # check for unused arguments (overriding extended rule)
   '@typescript-eslint/no-unused-vars':
     - warn

--- a/cypress/e2e/setup.cy.ts
+++ b/cypress/e2e/setup.cy.ts
@@ -1,3 +1,4 @@
+import { processAcl } from '../../src/utils/helpers'
 import { UserConfig } from '../support/css-authentication'
 import { CommunityConfig, SkipOptions } from '../support/setup'
 
@@ -234,8 +235,58 @@ describe('Setup Solid pod', () => {
 
     it('should join this community just fine', () => {
       cy.get<UserConfig>('@user1').then(user => cy.login(user))
+      cy.get(`input[type=radio]`).first().check()
       cy.contains('button', 'Continue!').click()
       cy.contains('a', 'travel')
     })
+
+    it('should show option to choose other community folder, or create a new one', () => {
+      cy.get<UserConfig>('@user1').then(cy.login)
+      // cy.contains(
+      //   'You are already a member of communities:' +
+      //     Cypress.env('OTHER_COMMUNITY'),
+      // )
+      cy.get<UserConfig>('@user1').then(user => {
+        cy.get(
+          `input[type=radio][value="${user.podUrl}hospex/other-community/card"]`,
+        ).check()
+      })
+      cy.contains('button', 'Continue!').click()
+      cy.contains('a', 'travel')
+
+      // check that both communities still have access
+      cy.get<CommunityConfig>('@community').then(community => {
+        cy.get<CommunityConfig>('@otherCommunity').then(otherCommunity => {
+          cy.get<UserConfig>('@user1').then(user => {
+            const url = `${user.podUrl}hospex/other-community/.acl`
+            cy.authenticatedRequest(user, {
+              url,
+              method: 'GET',
+              failOnStatusCode: true,
+            }).then(response => {
+              cy.log(response.body)
+              const acls = processAcl(url, response.body)
+
+              const read = acls.find(
+                acl => acl.accesses.length === 1 && acl.accesses[0] === 'Read',
+              )
+
+              expect(read.agentGroups)
+                .to.have.length(2)
+                .and.to.include(community.group)
+                .and.to.include(otherCommunity.group)
+            })
+          })
+        })
+      })
+    })
+
+    it('should explain implications of choosing other community folder')
+
+    it(
+      'should use current community folder and not break it for the other community',
+    )
+
+    it('should not break email notifications of the other community')
   })
 })

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "module": "esnext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "esModuleInterop": true,
     "target": "es5",
     "lib": ["es5", "dom", "esnext"],

--- a/src/hooks/data/queries/hospex.ts
+++ b/src/hooks/data/queries/hospex.ts
@@ -60,4 +60,19 @@ export const privateProfileAndHospexDocumentQuery: RdfQuery = [
     target: '?hospexSettings',
   },
   personInbox,
+  // get all communities that are set up
+  {
+    type: 'match',
+    subject: '?person',
+    predicate: sioc.member_of,
+    pick: 'object',
+    target: '?eachCommunity',
+  },
+  {
+    type: 'match',
+    subject: '?eachCommunity',
+    predicate: sioc.name,
+    pick: 'object',
+    target: '?communityName',
+  },
 ]

--- a/src/ldo/app.context.ts
+++ b/src/ldo/app.context.ts
@@ -225,6 +225,7 @@ export const appContext: ContextDefinition = {
   memberOf: {
     '@id': 'http://rdfs.org/sioc/ns#member_of',
     '@type': '@id',
+    '@container': '@set',
   },
   storage2: {
     '@id': 'http://w3id.org/hospex/ns#storage',

--- a/src/ldo/app.schema.ts
+++ b/src/ldo/app.schema.ts
@@ -301,6 +301,8 @@ export const appSchema: Schema = {
                 type: 'NodeConstraint',
                 nodeKind: 'iri',
               },
+              min: 0,
+              max: -1,
             },
             {
               type: 'TripleConstraint',

--- a/src/ldo/app.typings.ts
+++ b/src/ldo/app.typings.ts
@@ -98,9 +98,9 @@ export interface HospexProfile {
    * Accommodation that the person offers
    */
   offers?: Accommodation[]
-  memberOf: {
+  memberOf?: {
     '@id': string
-  }
+  }[]
   storage2: {
     '@id': string
   }

--- a/src/pages/SetupOutlet.tsx
+++ b/src/pages/SetupOutlet.tsx
@@ -27,6 +27,7 @@ export const SetupOutlet = () => {
     'publicTypeIndexes',
     'privateTypeIndexes',
     'personalHospexDocuments',
+    'allHospexDocuments',
   ])
 
   // set up email

--- a/src/shapes/app.shex
+++ b/src/shapes/app.shex
@@ -61,7 +61,7 @@ ex:HospexProfile {
   vcard:hasPhoto IRI? ;
   hospex:offers @ex:Accommodation *
     // rdfs:comment "Accommodation that the person offers" ;
-  sioc:member_of IRI ;
+  sioc:member_of IRI * ;
   hospex:storage IRI ;
 }
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,14 @@
+export class HttpError extends Error {
+  public statusCode: number
+  public response: any
+
+  constructor(statusCode: number, message: string, response: any) {
+    super(message)
+    this.name = 'HttpError'
+    this.statusCode = statusCode
+    this.response = response
+
+    // Set the prototype explicitly to maintain correct instance type
+    Object.setPrototypeOf(this, HttpError.prototype)
+  }
+}


### PR DESCRIPTION
In effect, this allows people to choose to use the same data for multiple communities. This is especially useful when communities are similar and overlapping, or when person wants to keep one profile across many hospitality exchanges.

Follow-ups:

- Fix overwriting issue with email notifications during setup #110 
- Improve user experience of joining - probably make multiple steps and clear choices and explanation