### PR TITLE
Add solidweb.me back to recommended providers

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -55,6 +55,7 @@ export const oidcIssuers: IssuerConfig[] = [
   {
     featured: true,
     issuer: 'https://solidweb.me/',
+    registration: 'https://solidweb.me/.account/login/password/register/',
     server: 'CSS',
   },
   {
@@ -81,6 +82,12 @@ export const oidcIssuers: IssuerConfig[] = [
     issuer: 'https://inrupt.net',
     registration: 'https://inrupt.net/register',
     server: 'NSS',
+  },
+  {
+    issuer: 'https://pods.solidcommunity.au',
+    registration:
+      'https://pods.solidcommunity.au/.account/login/password/register/',
+    server: 'CSS',
   },
 ]
 


### PR DESCRIPTION
It seems that its deprecation has been prevented

Additionally, add pod provider at pods.solidcommunity.au

Resolves #91