### PR TITLE
Allow manual trigger of deployment on GitHub

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: # Allows manual triggering
 
 jobs:
   build:


### PR DESCRIPTION
This should allow new community app instances to be published to GitHub Pages after forking the repository.