### PR TITLE
Clarify the attribution and license of the project

### DIFF
--- a/.github/workflows/notify-on-issues.yml
+++ b/.github/workflows/notify-on-issues.yml
@@ -1,3 +1,25 @@
+# MIT License
+
+# Copyright (c) 2023 Open Hospitality Network
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 name: Notify matrix room when an issue is created
 
 on: {}

--- a/.github/workflows/notify-on-pull-requests.yml
+++ b/.github/workflows/notify-on-pull-requests.yml
@@ -1,3 +1,25 @@
+# MIT License
+
+# Copyright (c) 2023 Open Hospitality Network
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 name: Notify matrix room when a pull request is opened (or reopened) or merged (or rebased)
 
 # pull_request payload docs: https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request

--- a/NOTICE
+++ b/NOTICE
@@ -5,3 +5,5 @@ This repository is licensed under the MIT License.
 However, please note that the logos, trademarks, and designs included in this repository
 are not covered by this license. They are the property of their respective owners and may
 not be used without permission.
+
+This codebase was originally developed as part of the Open Hospitality Network (OHN) and has been subsequently relicensed to SolidCouch under the current license (MIT). Any remaining files that are still licensed under OHN retain their original license (MIT), and these files are clearly marked with the original OHN license.

--- a/docs/Personas.md
+++ b/docs/Personas.md
@@ -51,3 +51,29 @@ What I want to do:
   - can it just show when I accept?
 - I'm going on vacation so I want to block that time
   - also if I accept someone, maybe show I can't take people in?
+
+## License for this document
+
+```
+MIT License
+
+Copyright (c) 2023 Open Hospitality Network
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/src/hooks/data/useRdfDocument.ts
+++ b/src/hooks/data/useRdfDocument.ts
@@ -126,6 +126,8 @@ export const useCreateRdfDocument = <S extends LdoBase>(
         setLanguagePreferences(language).using(ldo)
         merge(ldo, data)
       }
+
+      // For license and copyright purposes, please refer to https://github.com/solidcouch/solidcouch/pull/88/commits/5c3e71bd98b505e386c6f48f62fce409ccfd9d6f for authorship of the following lines.
       const body = await toTurtle(
         ldoDataset.usingType(shapeType).fromSubject(''),
       )

--- a/src/pages/About/About.tsx
+++ b/src/pages/About/About.tsx
@@ -1,3 +1,27 @@
+/*
+MIT License
+
+Copyright (c) 2023 Open Hospitality Network
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 import Markdown from 'react-markdown'
 import styles from './About.module.scss'
 import { about } from './data'

--- a/src/pages/UnauthenticatedHome.tsx
+++ b/src/pages/UnauthenticatedHome.tsx
@@ -59,20 +59,6 @@ export const UnauthenticatedHome = () => {
       </section>
       <div className={styles.spacer} />
       <footer className={styles.footer}>
-        {/* Visit our project spaces to{' '}
-        <a href="https://matrix.to/#/#todo:matrix.org">
-          ask a question or join the team
-        </a>,
-        {/* or <a href="https://opencollective.com/todo">support us financially</a>. */}
-        {/* <br />
-        Follow us in the{' '}
-        <a rel="me" href="https://floss.social/@todo">
-          Fediverse
-        </a>{' '}
-        or on{' '}
-        <a rel="me" href="https://www.facebook.com/todo/">
-          Facebook
-        </a>. */}
         <div className={styles.footerInfo}>WIP</div>
         <div className={styles.attribution}>
           Powered by <a href="https://github.com/solidcouch">SolidCouch</a>


### PR DESCRIPTION
This codebase was originally developed as part of the Open Hospitality Network (OHN) and has been [subsequently relicensed](https://github.com/solidcouch/solidcouch/commit/1ca1193366ff5b1f5feede182f24d64ea3a9f178#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7) to SolidCouch under the [current license](https://github.com/solidcouch/solidcouch/blob/main/LICENSE) (MIT). Any remaining files that are still licensed under OHN retain their [original license](https://github.com/solidcouch/solidcouch/blob/6a75684ba36410c5213b1d815cdddc6361643006/LICENSE) (MIT), and these files are clearly marked with the original OHN license.

This change is necessary to address missing consent with the relicensing.

Approaches:
- Include previous license in relevant files
- Remove code