### PR TITLE
chore: update GitHub Actions artifact to v4 due to deprecated v3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
           VITE_DARK_MODE_LOGO_STYLE: ${{ vars.DARK_MODE_LOGO_STYLE }}
 
       - name: Upload production-ready build files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: production-files
           path: ./dist
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: production-files
           path: ./dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add dark theme
-- Integrate joining community via [community inbox service](https://github.com/solidcouch/community-inbox)
+- Add dark theme.
+- Integrate joining community via [community inbox service](https://github.com/solidcouch/community-inbox).
 
 ### Changed
 
-- Change default dev community from [dev-sleepy-bike](https://solidweb.me/dev-sleepy-bike/community#us) to [solidcouch](https://solidweb.me/solidcouch/community#us)
+- Change default dev community from [dev-sleepy-bike](https://solidweb.me/dev-sleepy-bike/community#us) to [solidcouch](https://solidweb.me/solidcouch/community#us).
+- Update GitHub Actions artifact to v4 due to deprecated v3.
 
 ### Fixed
 
-- Fix non-serializable value error in redux-persist
+- Fix non-serializable value error in redux-persist.
 
 ## [0.2.0] - 2025-01-01
 


### PR DESCRIPTION
https://github.com/actions/upload-artifact/
![image](https://github.com/user-attachments/assets/1ccaf741-612e-4c71-80c9-6d8c00156bea)

https://github.com/actions/download-artifact/
![image](https://github.com/user-attachments/assets/de2f063e-f754-4ae3-a8ef-830a518ae18a)

from email notification
![image](https://github.com/user-attachments/assets/35a3c2f5-9dda-45a4-a2b1-d51f536bcf3a)
