### PR TITLE
chore: fix tests for firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix a bug in wikidata data parsing.
+- Fix tests running in firefox
 
 ## [0.3.0] - 2025-02-19
 

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -18,6 +18,18 @@ export default defineConfig({
     viewportWidth: 375,
     viewportHeight: 812,
     setupNodeEvents(on) {
+      // https://github.com/cypress-io/cypress/issues/14600#issuecomment-1614013583
+      on('before:browser:launch', (browser, launchOptions) => {
+        if (browser.family === 'firefox') {
+          // launchOptions.preferences is a map of preference names to values
+          // login is not working in firefox when testing_localhost_is_secure_when_hijacked is false
+          launchOptions.preferences[
+            'network.proxy.testing_localhost_is_secure_when_hijacked'
+          ] = true
+        }
+
+        return launchOptions
+      })
       on('task', {
         log(message) {
           // eslint-disable-next-line no-console


### PR DESCRIPTION
Previously, the tests were failing on Firefox because crypto.subtle was undefined.