### PR TITLE
fix: redirect to root after signout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix a bug in wikidata data parsing.
 - Fix tests running in firefox.
 - Save preferences file during setup.
+- Redirect to root after signout.
 
 ## [0.3.0] - 2025-02-19
 

--- a/src/components/SignOut.tsx
+++ b/src/components/SignOut.tsx
@@ -2,12 +2,15 @@ import * as authSlice from '@/redux/authSlice'
 import { useAppDispatch } from '@/redux/hooks'
 import { logout } from '@inrupt/solid-client-authn-browser'
 import { Trans } from '@lingui/react/macro'
+import { useNavigate } from 'react-router-dom'
 
 export const SignOut = () => {
   const dispatch = useAppDispatch()
+  const navigate = useNavigate()
   const handleSignout = async () => {
     await logout()
     dispatch(authSlice.actions.signout())
+    navigate('/')
   }
 
   return (

--- a/src/locales/cs.po
+++ b/src/locales/cs.po
@@ -573,7 +573,7 @@ msgstr "Ukázat poskytovatele!"
 msgid "Sign in"
 msgstr "Přihlásit se"
 
-#: src/components/SignOut.tsx:15
+#: src/components/SignOut.tsx:18
 msgid "sign out"
 msgstr "odhlásit se"
 

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -573,7 +573,7 @@ msgstr "Show me some providers!"
 msgid "Sign in"
 msgstr "Sign in"
 
-#: src/components/SignOut.tsx:15
+#: src/components/SignOut.tsx:18
 msgid "sign out"
 msgstr "sign out"
 


### PR DESCRIPTION
Leave the previous route, and go to `/`