### PR TITLE
refactor: redirect to previous uri after page refresh

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,11 +28,6 @@ export const App = () => {
 
   useEffect(() => {
     ;(async () => {
-      const currentUrl = globalThis.location.href
-      // eslint-disable-next-line lingui/no-unlocalized-strings
-      if (!currentUrl.includes('?code='))
-        // eslint-disable-next-line lingui/no-unlocalized-strings
-        globalThis.localStorage.setItem('previousUrl', currentUrl)
       const session = await handleIncomingRedirect({
         restorePreviousSession: true,
       })

--- a/src/locales/cs.po
+++ b/src/locales/cs.po
@@ -379,7 +379,7 @@ msgstr "načítání zájmů..."
 msgid "Loading previous messages"
 msgstr "Načítání předchozích zpráv"
 
-#: src/App.tsx:52
+#: src/App.tsx:47
 #: src/pages/messages-old/MessagesOld.tsx:205
 #: src/pages/MyOffers.tsx:95
 #: src/pages/Profile/ManageContact.tsx:26

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -379,7 +379,7 @@ msgstr "loading interests..."
 msgid "Loading previous messages"
 msgstr "Loading previous messages"
 
-#: src/App.tsx:52
+#: src/App.tsx:47
 #: src/pages/messages-old/MessagesOld.tsx:205
 #: src/pages/MyOffers.tsx:95
 #: src/pages/Profile/ManageContact.tsx:26


### PR DESCRIPTION
using recommended approach in https://docs.inrupt.com/guides/authentication-in-solid/authentication-from-browser/session-restore-upon-browser-refresh instead of storing the value in local storage

also correctly unsubscribe the event listener after useEffect

Supersedes #169